### PR TITLE
source: Honor `basedir` xml element

### DIFF
--- a/libhif/hif-source.c
+++ b/libhif/hif-source.c
@@ -1688,7 +1688,7 @@ hif_source_download_package (HifSource *source,
 				  hif_source_checksum_hy_to_lr (checksum_type),
 				  checksum_str,
 				  0, /* size unknown */
-				  NULL, /* baseurl not required */
+				  hy_package_get_baseurl (pkg),
 				  TRUE,
 				  &error_local);
 	if (!ret) {


### PR DESCRIPTION
I encountered this in the wild on a Red Hat internal system.
Apparently it's possible for the XML to include an alternative baseurl
too.