### PR TITLE
context: Don't do entitlements for alternative install roots

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -1224,6 +1224,15 @@ hif_context_setup_enrollments (HifContext *context, GError **error)
 	if (priv->enrollment_valid)
 		return TRUE;
 
+	/* Let's assume that alternative installation roots don't
+	 * require entitlement.  We only want to do system things if
+	 * we're actually affecting the system.  A more accurate test
+	 * here would be checking that we're using /etc/yum.repos.d or
+	 * so, but that can come later.
+	 */
+	if (g_strcmp0 (priv->install_root, "/") != 0)
+		return TRUE;
+
 	for (i = 0; cmds[i] != NULL; i++) {
 		_cleanup_strv_free_ gchar **argv = g_strsplit (cmds[i], " ", -1);
 		if (!g_file_test (argv[0], G_FILE_TEST_EXISTS))


### PR DESCRIPTION
Using rpm-ostree shouldn't try to check or update my host repo's
entitlement status.

Conflicts:
	libhif/hif-context.c