### PR TITLE
source: Request multiple packages at once from librepo

### DIFF
--- a/libhif/hif-source.h
+++ b/libhif/hif-source.h
@@ -192,6 +192,11 @@ gchar		*hif_source_download_package	(HifSource		*source,
 						 const gchar		*directory,
 						 HifState		*state,
 						 GError			**error);
+gboolean        hif_source_download_packages	(HifSource		*source,
+						 GPtrArray		*pkgs,
+						 const gchar		*directory,
+						 HifState		*state,
+						 GError			**error);
 #endif
 
 G_END_DECLS


### PR DESCRIPTION
Ultimately, what we want here is to ensure we're using HTTP
keep-alives.  While curl does have some support for automatically
reusing connections behind the scenes, it's going to work more
reliably when we hand librepo multiple requests at once.

To do that, we need to determine which requested packages come from
which source.

Even better would be to parallelize downloads from multiple sources,
but that can be a later PR.

My long term goal here is to change rpm-ostree to unpack RPMs as
they're being downloaded, which would be a dramatic efficiency
improvement.