### PR TITLE
Add support for retrieving Group tag from package

### DIFF
--- a/libhif/hy-package.c
+++ b/libhif/hy-package.c
@@ -552,6 +552,22 @@ hif_package_get_evr(HifPackage *pkg)
 }
 
 /**
+ * hif_package_get_group:
+ * @pkg: a #HifPackage instance.
+ *
+ * Gets the group for the package.
+ *
+ * Returns: a string, or %NULL
+ *
+ * Since: 0.7.0
+ */
+const char *
+hif_package_get_group(HifPackage *pkg)
+{
+  return solvable_lookup_str(get_solvable(pkg), SOLVABLE_GROUP);
+}
+
+/**
  * hif_package_get_license:
  * @pkg: a #HifPackage instance.
  *

--- a/libhif/hy-package.h
+++ b/libhif/hy-package.h
@@ -66,6 +66,7 @@ const char  *hif_package_get_arch       (HifPackage *pkg);
 const unsigned char *hif_package_get_chksum(HifPackage *pkg, int *type);
 const char  *hif_package_get_description(HifPackage *pkg);
 const char  *hif_package_get_evr        (HifPackage *pkg);
+const char  *hif_package_get_group      (HifPackage *pkg);
 const char  *hif_package_get_license    (HifPackage *pkg);
 const unsigned char *hif_package_get_hdr_chksum(HifPackage *pkg, int *type);
 const char  *hif_package_get_packager   (HifPackage *pkg);

--- a/python/hawkey/package-py.c
+++ b/python/hawkey/package-py.c
@@ -296,6 +296,7 @@ static PyGetSetDef package_getsetters[] = {
     {"description", (getter)get_str, NULL, NULL,
      (void *)hif_package_get_description},
     {"evr",  (getter)get_str, NULL, NULL, (void *)hif_package_get_evr},
+    {"group",  (getter)get_str, NULL, NULL, (void *)hif_package_get_group},
     {"license", (getter)get_str, NULL, NULL, (void *)hif_package_get_license},
     {"packager",  (getter)get_str, NULL, NULL, (void *)hif_package_get_packager},
     {"reponame",  (getter)get_str, NULL, NULL, (void *)hif_package_get_reponame},


### PR DESCRIPTION
In Mageia (and some other distributions), the Group tag serves a purpose: categorizing what kind of packages they are. This pull request exposes that information from the package data.

This is based on [my original pull request to hawkey](https://github.com/rpm-software-management/hawkey/pull/114).