### PR TITLE
run the valgrind tests only if valgrind is available

### DIFF
--- a/tests/hawkey/CMakeLists.txt
+++ b/tests/hawkey/CMakeLists.txt
@@ -34,9 +34,11 @@ TARGET_LINK_LIBRARIES(test_main
     ${ZLIB_LIBRARY}
     ${RPMDB_LIBRARY})
 ADD_TEST(test_main test_main "${CMAKE_CURRENT_SOURCE_DIR}/repos/")
-ADD_TEST(test_valgrind ${VALGRIND_PROGRAM} --error-exitcode=1 --leak-check=full
+IF (VALGRIND_PROGRAM)
+    ADD_TEST(test_valgrind ${VALGRIND_PROGRAM} --error-exitcode=1 --leak-check=full
                        ${CMAKE_CURRENT_BINARY_DIR}/test_main
                        ${CMAKE_CURRENT_SOURCE_DIR}/repos/)
-SET_TESTS_PROPERTIES(test_valgrind PROPERTIES ENVIRONMENT "CK_FORK=no")
+    SET_TESTS_PROPERTIES(test_valgrind PROPERTIES ENVIRONMENT "CK_FORK=no")
+ENDIF()
 
 ADD_SUBDIRECTORY (python)


### PR DESCRIPTION
this is for the cmake based buildsystem, there seems to used a mix of autoconf & cmake

see also https://bugzilla.redhat.com/show_bug.cgi?id=1289865 (originally seen in hawkey)