### PR TITLE
source: Expose librepo internals

### DIFF
--- a/libhif/hif-source.c
+++ b/libhif/hif-source.c
@@ -405,6 +405,20 @@ hif_source_get_repo (HifSource *source)
 	return priv->repo;
 }
 
+LrHandle *
+hif_source_get_lrhandle (HifSource              *source)
+{
+	HifSourcePrivate *priv = GET_PRIVATE (source);
+	return priv->repo_handle;
+}
+
+LrResult *
+hif_source_get_lrresult (HifSource              *source)
+{
+	HifSourcePrivate *priv = GET_PRIVATE (source);
+	return priv->repo_result;
+}
+
 /**
  * hif_source_is_devel:
  * @source: a #HifSource instance.

--- a/libhif/hif-source.h
+++ b/libhif/hif-source.h
@@ -30,6 +30,9 @@
 
 #include <hawkey/repo.h>
 #include <hawkey/package.h>
+#ifndef __GI_SCANNER__
+#include <librepo/librepo.h>
+#endif
 
 #include "hif-context.h"
 #include "hif-state.h"
@@ -134,7 +137,9 @@ const gchar	*hif_source_get_filename_md	(HifSource		*source,
 						 const gchar		*md_kind);
 #ifndef __GI_SCANNER__
 HyRepo		 hif_source_get_repo		(HifSource		*source);
-#endif
+LrHandle *       hif_source_get_lrhandle        (HifSource              *source);
+LrResult *       hif_source_get_lrresult        (HifSource              *source);
+#endif 
 gboolean	 hif_source_is_devel		(HifSource		*source);
 gboolean	 hif_source_is_local		(HifSource		*source);
 gboolean	 hif_source_is_source		(HifSource		*source);


### PR DESCRIPTION
For a while I've been wanting to rework rpm-ostree to more tightly
integrate rpm components.  Specifically I'm working on storing
cached rpms *unpacked* in the ostree repo itself.  This solves
numerous problems.

However, I can't easily teach libhif about ostree from the outside.
Also, I want to solve some other things like parallel downloads, etc.

I know there's a major revamp coming, I plan to look at that after it
lands.

In the meantime, exposing these two bits for librepo allows me to
implement downloading while still reusing some of the other useful
bits of `HifSource`.