### PR TITLE
keyring: Include rpm name in the error message when gpg key check fails

### DIFF
--- a/libhif/hif-keyring.c
+++ b/libhif/hif-keyring.c
@@ -286,7 +286,8 @@ hif_keyring_check_untrusted_file (rpmKeyring keyring,
 		g_set_error_literal (error,
 				     HIF_ERROR,
 				     HIF_ERROR_GPG_SIGNATURE_INVALID,
-				     "failed to lookup digest in keyring");
+				     "failed to lookup digest in keyring for %s",
+				     filename);
 		goto out;
 	}
 


### PR DESCRIPTION
https://bugzilla.gnome.org/show_bug.cgi?id=760878