### PR TITLE
build: Install hawkey headers too (temporarily)

### DIFF
--- a/libhif/CMakeLists.txt
+++ b/libhif/CMakeLists.txt
@@ -63,6 +63,20 @@ TARGET_LINK_LIBRARIES(hth libhif
                       ${ZLIB_LIBRARY}
                       ${RPMDB_LIBRARY})
 
+SET(LIBHAWKEY_headers
+    hy-goal.h
+    hy-nevra.h
+    hy-package.h
+    hy-packageset.h
+    hy-query.h
+    hy-reldep.h
+    hy-repo.h
+    hy-selector.h
+    hy-subject.h
+    hy-types.h
+    hy-util.h
+    )
+
 SET(LIBHIF_headers
     hif-advisory.h
     hif-advisorypkg.h
@@ -163,4 +177,5 @@ endif()
 INSTALL(FILES "libhif.pc"
         DESTINATION "${LIB_INSTALL_DIR}/pkgconfig")
 INSTALL(FILES ${LIBHIF_headers} DESTINATION include/libhif)
+INSTALL(FILES ${LIBHAWKEY_headers} DESTINATION include/libhif)
 INSTALL(TARGETS libhif LIBRARY DESTINATION ${LIB_INSTALL_DIR})

--- a/libhif/hif-context.h
+++ b/libhif/hif-context.h
@@ -25,7 +25,7 @@
 #include "hif-types.h"
 
 #ifndef __GI_SCANNER__
-#include "hy-goal.h"
+#include "hif-transaction.h"
 #include "hif-sack.h"
 #endif
 

--- a/libhif/libhif.h
+++ b/libhif/libhif.h
@@ -44,6 +44,18 @@
 #include <libhif/hif-utils.h>
 #include <libhif/hif-version.h>
 
+/* In progress conversion to hif */
+#include <libhif/hy-goal.h>
+#include <libhif/hy-nevra.h>
+#include <libhif/hy-package.h>
+#include <libhif/hy-packageset.h>
+#include <libhif/hy-query.h>
+#include <libhif/hy-reldep.h>
+#include <libhif/hy-repo.h>
+#include <libhif/hy-selector.h>
+#include <libhif/hy-subject.h>
+#include <libhif/hy-util.h>
+
 #undef __LIBHIF_H_INSIDE__
 
 #endif /* __LIBHIF_H */


### PR DESCRIPTION
I'm in the midst of porting rpm-ostree, and I need things like
`HyGoal`.  Trying not to do a full gobject conversion before getting
things compiling.