### PR TITLE
repo: Expose librepo internals

### DIFF
--- a/libhif/hif-repo.c
+++ b/libhif/hif-repo.c
@@ -1634,6 +1634,20 @@ out:
     return LR_CB_OK;
 }
 
+LrHandle *
+hif_repo_get_lr_handle (HifRepo              *repo)
+{
+    HifRepoPrivate *priv = GET_PRIVATE (repo);
+    return priv->repo_handle;
+}
+
+LrResult *
+hif_repo_get_lr_result (HifRepo              *repo)
+{
+    HifRepoPrivate *priv = GET_PRIVATE (repo);
+    return priv->repo_result;
+}
+
 /**
  * hif_repo_download_package:
  * @repo: a #HifRepo instance.

--- a/libhif/hif-repo.h
+++ b/libhif/hif-repo.h
@@ -30,6 +30,8 @@
 #include "hif-context.h"
 #include "hif-state.h"
 
+#include <librepo/librepo.h>
+
 G_BEGIN_DECLS
 
 #define HIF_TYPE_REPO (hif_repo_get_type ())
@@ -170,6 +172,11 @@ gboolean         hif_repo_set_data              (HifRepo              *repo,
                                                  GError              **error);
 gboolean         hif_repo_commit                (HifRepo              *repo,
                                                  GError              **error);
+
+LrHandle *       hif_repo_get_lr_handle         (HifRepo              *repo);
+
+LrResult *       hif_repo_get_lr_result         (HifRepo              *repo);
+
 #ifndef __GI_SCANNER__
 gchar           *hif_repo_download_package      (HifRepo              *repo,
                                                  HifPackage *            pkg,


### PR DESCRIPTION
Right now rpm-ostree is carrying the patch for parallel downloads,
let's add this until I can rework that code to again land in libhif.