### PR TITLE
sack: Avoid tripping assertion with zero-sized excludes

### DIFF
--- a/libhif/hif-sack.c
+++ b/libhif/hif-sack.c
@@ -1661,7 +1661,8 @@ process_excludes(HifSack *sack, HifRepo *repo)
         hy_query_filter(query, HY_PKG_NAME, HY_EQ, name);
         pkgset = hy_query_run_set(query);
 
-        hif_sack_add_excludes(sack, pkgset);
+        if (hif_packageset_count(pkgset) > 0)
+            hif_sack_add_excludes(sack, pkgset);
 
         hy_query_free(query);
         g_object_unref(pkgset);


### PR DESCRIPTION
I'll be honest, I don't understand what's going on in this code.  I
dimly remember some discussion of how excludes were processed in dnf
requiring changes in libsolv, and I suspect that change didn't make it
into the version I put in libhif?

In my case, I have an `excludes=` in a repo file, but the package
isn't actually there, so I don't actually need to process the exclude.
Skipping calling this function if the result is zero avoids a crash.

But it's clearly not the right fix - posting this to generate a
discussion about the right one.