### PR TITLE
Actions

### DIFF
--- a/libhif/hif-goal.c
+++ b/libhif/hif-goal.c
@@ -50,7 +50,7 @@ hif_goal_depsolve(HyGoal goal, GError **error)
     gint rc;
     g_autoptr(GString) string = NULL;
 
-    rc = hy_goal_run_flags(goal, HY_ALLOW_UNINSTALL);
+    rc = hy_goal_run_flags(goal, HIF_ALLOW_UNINSTALL);
     if (rc) {
         string = g_string_new("Could not depsolve transaction; ");
         cnt = hy_goal_count_problems(goal);

--- a/libhif/hy-goal.c
+++ b/libhif/hy-goal.c
@@ -819,6 +819,7 @@ hy_goal_run_all_flags(HyGoal goal, hy_solution_callback cb, void *cb_data,
                       int flags)
 {
     Queue *job = construct_job(goal, flags);
+    goal->actions |= flags;
     int ret = solve(goal, job, flags, cb, cb_data);
     free_job(job);
     return ret;

--- a/libhif/hy-goal.c
+++ b/libhif/hy-goal.c
@@ -49,7 +49,7 @@ struct _HyGoal {
     Queue staging;
     Solver *solv;
     Transaction *trans;
-    int actions;
+    enum _hy_goal_actions actions;
 };
 
 struct _SolutionCallback {
@@ -199,7 +199,7 @@ internal_solver_callback(Solver *solv, void *data)
 }
 
 static Solver *
-init_solver(HyGoal goal, int flags)
+init_solver(HyGoal goal, enum _hy_goal_actions flags)
 {
     Pool *pool = hif_sack_get_pool(goal->sack);
     Solver *solv = solver_create(pool);
@@ -223,8 +223,8 @@ init_solver(HyGoal goal, int flags)
 }
 
 static int
-solve(HyGoal goal, Queue *job, int flags, hy_solution_callback user_cb,
-      void * user_cb_data)
+solve(HyGoal goal, Queue *job, enum _hy_goal_actions flags,
+      hy_solution_callback user_cb, void * user_cb_data)
 {
     HifSack *sack = goal->sack;
     struct _SolutionCallback cb_tuple;
@@ -265,7 +265,7 @@ solve(HyGoal goal, Queue *job, int flags, hy_solution_callback user_cb,
 }
 
 static Queue *
-construct_job(HyGoal goal, int flags)
+construct_job(HyGoal goal, enum _hy_goal_actions flags)
 {
     HifSack *sack = goal->sack;
     Queue *job = g_malloc(sizeof(*job));
@@ -674,7 +674,7 @@ hy_goal_erase_selector_flags(HyGoal goal, HySelector sltr, int flags)
 }
 
 int
-hy_goal_has_actions(HyGoal goal, int action)
+hy_goal_has_actions(HyGoal goal, enum _hy_goal_actions action)
 {
     return goal->actions & action;
 }
@@ -803,7 +803,7 @@ hy_goal_run(HyGoal goal)
 }
 
 int
-hy_goal_run_flags(HyGoal goal, int flags)
+hy_goal_run_flags(HyGoal goal, enum _hy_goal_actions flags)
 {
     return hy_goal_run_all_flags(goal, NULL, NULL, flags);
 }
@@ -816,7 +816,7 @@ hy_goal_run_all(HyGoal goal, hy_solution_callback cb, void *cb_data)
 
 int
 hy_goal_run_all_flags(HyGoal goal, hy_solution_callback cb, void *cb_data,
-                      int flags)
+                      enum _hy_goal_actions flags)
 {
     Queue *job = construct_job(goal, flags);
     goal->actions |= flags;

--- a/libhif/hy-goal.h
+++ b/libhif/hy-goal.h
@@ -83,16 +83,16 @@ int hy_goal_upgrade_to_selector(HyGoal goal, HySelector sltr);
 int hy_goal_userinstalled(HyGoal goal, HifPackage *pkg);
 
 /* introspecting the requests */
-int hy_goal_has_actions(HyGoal goal, int action);
+int hy_goal_has_actions(HyGoal goal, enum _hy_goal_actions action);
 
 int hy_goal_req_length(HyGoal goal);
 
 /* resolving the goal */
 int hy_goal_run(HyGoal goal);
-int hy_goal_run_flags(HyGoal goal, int flags);
+int hy_goal_run_flags(HyGoal goal, enum _hy_goal_actions flags);
 int hy_goal_run_all(HyGoal goal, hy_solution_callback cb, void *cb_data);
 int hy_goal_run_all_flags(HyGoal goal, hy_solution_callback cb, void *cb_data,
-                          int flags);
+                          enum _hy_goal_actions flags);
 
 /* problems */
 int hy_goal_count_problems(HyGoal goal);

--- a/libhif/hy-goal.h
+++ b/libhif/hy-goal.h
@@ -34,13 +34,6 @@ enum _hy_goal_op_flags {
     HY_WEAK_SOLV                = 1 << 2
 };
 
-enum _hy_goal_run_flags {
-    HY_ALLOW_UNINSTALL          = 1 << 0,
-    HY_FORCE_BEST               = 1 << 1,
-    HY_VERIFY                   = 1 << 2,
-    HY_IGNORE_WEAK_DEPS         = 1 << 3
-};
-
 enum _hy_goal_actions {
     HY_ERASE                    = 1 << 0,
     HY_DISTUPGRADE              = 1 << 1,
@@ -49,6 +42,12 @@ enum _hy_goal_actions {
     HY_INSTALL                  = 1 << 4,
     HY_UPGRADE                  = 1 << 5,
     HY_UPGRADE_ALL              = 1 << 6,
+
+    // hy_goal_run flags
+    HY_ALLOW_UNINSTALL          = 1 << 10,
+    HY_FORCE_BEST               = 1 << 11,
+    HY_VERIFY                   = 1 << 12,
+    HY_IGNORE_WEAK_DEPS         = 1 << 13
 };
 
 #define HY_REASON_DEP 1

--- a/libhif/hy-goal.h
+++ b/libhif/hy-goal.h
@@ -34,21 +34,21 @@ enum _hy_goal_op_flags {
     HY_WEAK_SOLV                = 1 << 2
 };
 
-enum _hy_goal_actions {
-    HY_ERASE                    = 1 << 0,
-    HY_DISTUPGRADE              = 1 << 1,
-    HY_DISTUPGRADE_ALL          = 1 << 2,
-    HY_DOWNGRADE                = 1 << 3,
-    HY_INSTALL                  = 1 << 4,
-    HY_UPGRADE                  = 1 << 5,
-    HY_UPGRADE_ALL              = 1 << 6,
+typedef enum {
+    HIF_ERASE                    = 1 << 0,
+    HIF_DISTUPGRADE              = 1 << 1,
+    HIF_DISTUPGRADE_ALL          = 1 << 2,
+    HIF_DOWNGRADE                = 1 << 3,
+    HIF_INSTALL                  = 1 << 4,
+    HIF_UPGRADE                  = 1 << 5,
+    HIF_UPGRADE_ALL              = 1 << 6,
 
     // hy_goal_run flags
-    HY_ALLOW_UNINSTALL          = 1 << 10,
-    HY_FORCE_BEST               = 1 << 11,
-    HY_VERIFY                   = 1 << 12,
-    HY_IGNORE_WEAK_DEPS         = 1 << 13
-};
+    HIF_ALLOW_UNINSTALL          = 1 << 10,
+    HIF_FORCE_BEST               = 1 << 11,
+    HIF_VERIFY                   = 1 << 12,
+    HIF_IGNORE_WEAK_DEPS         = 1 << 13
+} HifGoalActions;
 
 #define HY_REASON_DEP 1
 #define HY_REASON_USER 2
@@ -83,16 +83,16 @@ int hy_goal_upgrade_to_selector(HyGoal goal, HySelector sltr);
 int hy_goal_userinstalled(HyGoal goal, HifPackage *pkg);
 
 /* introspecting the requests */
-int hy_goal_has_actions(HyGoal goal, enum _hy_goal_actions action);
+int hy_goal_has_actions(HyGoal goal, HifGoalActions action);
 
 int hy_goal_req_length(HyGoal goal);
 
 /* resolving the goal */
 int hy_goal_run(HyGoal goal);
-int hy_goal_run_flags(HyGoal goal, enum _hy_goal_actions flags);
+int hy_goal_run_flags(HyGoal goal, HifGoalActions flags);
 int hy_goal_run_all(HyGoal goal, hy_solution_callback cb, void *cb_data);
 int hy_goal_run_all_flags(HyGoal goal, hy_solution_callback cb, void *cb_data,
-                          enum _hy_goal_actions flags);
+                          HifGoalActions flags);
 
 /* problems */
 int hy_goal_count_problems(HyGoal goal);

--- a/python/hawkey/__init__.py
+++ b/python/hawkey/__init__.py
@@ -157,6 +157,11 @@ INSTALL = _hawkey.INSTALL
 UPGRADE = _hawkey.UPGRADE
 UPGRADE_ALL = _hawkey.UPGRADE_ALL
 
+ALLOW_UNINSTALL = _hawkey.ALLOW_UNINSTALL
+FORCE_BEST = _hawkey.FORCE_BEST
+VERIFY = _hawkey.VERIFY
+IGNORE_WEAK_DEPS = _hawkey.IGNORE_WEAK_DEPS
+
 
 def split_nevra(s):
     t = _hawkey.split_nevra(s)

--- a/python/hawkey/goal-py.c
+++ b/python/hawkey/goal-py.c
@@ -133,13 +133,13 @@ args_run_parse(PyObject *args, PyObject *kwds, int *flags, PyObject **callback_p
     }
 
     if (allow_uninstall)
-        *flags |= HY_ALLOW_UNINSTALL;
+        *flags |= HIF_ALLOW_UNINSTALL;
     if (force_best)
-        *flags |= HY_FORCE_BEST;
+        *flags |= HIF_FORCE_BEST;
     if (verify)
-        *flags |= HY_VERIFY;
+        *flags |= HIF_VERIFY;
     if (ignore_weak_deps)
-        *flags |= HY_IGNORE_WEAK_DEPS;
+        *flags |= HIF_IGNORE_WEAK_DEPS;
     return 1;
 }
 
@@ -345,19 +345,19 @@ has_actions(_GoalObject *self, PyObject *action)
 static PyObject *
 req_has_distupgrade_all(_GoalObject *self, PyObject *unused)
 {
-    return PyBool_FromLong(hy_goal_has_actions(self->goal, HY_DISTUPGRADE_ALL));
+    return PyBool_FromLong(hy_goal_has_actions(self->goal, HIF_DISTUPGRADE_ALL));
 }
 
 static PyObject *
 req_has_erase(_GoalObject *self, PyObject *unused)
 {
-    return PyBool_FromLong(hy_goal_has_actions(self->goal, HY_ERASE));
+    return PyBool_FromLong(hy_goal_has_actions(self->goal, HIF_ERASE));
 }
 
 static PyObject *
 req_has_upgrade_all(_GoalObject *self, PyObject *unused)
 {
-    return PyBool_FromLong(hy_goal_has_actions(self->goal, HY_UPGRADE_ALL));
+    return PyBool_FromLong(hy_goal_has_actions(self->goal, HIF_UPGRADE_ALL));
 }
 
 static PyObject *

--- a/python/hawkey/hawkeymodule.c
+++ b/python/hawkey/hawkeymodule.c
@@ -267,18 +267,18 @@ PYCOMP_MOD_INIT(_hawkey)
     PyModule_AddIntConstant(m, "PKG_URL", HY_PKG_URL);
     PyModule_AddIntConstant(m, "PKG_VERSION", HY_PKG_VERSION);
 
-    PyModule_AddIntConstant(m, "ERASE", HY_ERASE);
-    PyModule_AddIntConstant(m, "DISTUPGRADE", HY_DISTUPGRADE);
-    PyModule_AddIntConstant(m, "DISTUPGRADE_ALL", HY_DISTUPGRADE_ALL);
-    PyModule_AddIntConstant(m, "DOWNGRADE", HY_DOWNGRADE);
-    PyModule_AddIntConstant(m, "INSTALL", HY_INSTALL);
-    PyModule_AddIntConstant(m, "UPGRADE", HY_UPGRADE);
-    PyModule_AddIntConstant(m, "UPGRADE_ALL", HY_UPGRADE_ALL);
+    PyModule_AddIntConstant(m, "ERASE", HIF_ERASE);
+    PyModule_AddIntConstant(m, "DISTUPGRADE", HIF_DISTUPGRADE);
+    PyModule_AddIntConstant(m, "DISTUPGRADE_ALL", HIF_DISTUPGRADE_ALL);
+    PyModule_AddIntConstant(m, "DOWNGRADE", HIF_DOWNGRADE);
+    PyModule_AddIntConstant(m, "INSTALL", HIF_INSTALL);
+    PyModule_AddIntConstant(m, "UPGRADE", HIF_UPGRADE);
+    PyModule_AddIntConstant(m, "UPGRADE_ALL", HIF_UPGRADE_ALL);
 
-    PyModule_AddIntConstant(m, "ALLOW_UNINSTALL", HY_ALLOW_UNINSTALL);
-    PyModule_AddIntConstant(m, "FORCE_BEST", HY_FORCE_BEST);
-    PyModule_AddIntConstant(m, "VERIFY", HY_VERIFY);
-    PyModule_AddIntConstant(m, "IGNORE_WEAK_DEPS", HY_IGNORE_WEAK_DEPS);
+    PyModule_AddIntConstant(m, "ALLOW_UNINSTALL", HIF_ALLOW_UNINSTALL);
+    PyModule_AddIntConstant(m, "FORCE_BEST", HIF_FORCE_BEST);
+    PyModule_AddIntConstant(m, "VERIFY", HIF_VERIFY);
+    PyModule_AddIntConstant(m, "IGNORE_WEAK_DEPS", HIF_IGNORE_WEAK_DEPS);
 
     PyModule_AddIntConstant(m, "CHKSUM_MD5", G_CHECKSUM_MD5);
     PyModule_AddIntConstant(m, "CHKSUM_SHA1", G_CHECKSUM_SHA1);

--- a/python/hawkey/hawkeymodule.c
+++ b/python/hawkey/hawkeymodule.c
@@ -274,7 +274,12 @@ PYCOMP_MOD_INIT(_hawkey)
     PyModule_AddIntConstant(m, "INSTALL", HY_INSTALL);
     PyModule_AddIntConstant(m, "UPGRADE", HY_UPGRADE);
     PyModule_AddIntConstant(m, "UPGRADE_ALL", HY_UPGRADE_ALL);
-    
+
+    PyModule_AddIntConstant(m, "ALLOW_UNINSTALL", HY_ALLOW_UNINSTALL);
+    PyModule_AddIntConstant(m, "FORCE_BEST", HY_FORCE_BEST);
+    PyModule_AddIntConstant(m, "VERIFY", HY_VERIFY);
+    PyModule_AddIntConstant(m, "IGNORE_WEAK_DEPS", HY_IGNORE_WEAK_DEPS);
+
     PyModule_AddIntConstant(m, "CHKSUM_MD5", G_CHECKSUM_MD5);
     PyModule_AddIntConstant(m, "CHKSUM_SHA1", G_CHECKSUM_SHA1);
     PyModule_AddIntConstant(m, "CHKSUM_SHA256", G_CHECKSUM_SHA256);

--- a/tests/hawkey/test_goal.c
+++ b/tests/hawkey/test_goal.c
@@ -144,9 +144,9 @@ START_TEST(test_goal_actions)
 {
     HifPackage *pkg = get_latest_pkg(test_globals.sack, "walrus");
     HyGoal goal = hy_goal_create(test_globals.sack);
-    fail_if(hy_goal_has_actions(goal, HY_INSTALL));
+    fail_if(hy_goal_has_actions(goal, HIF_INSTALL));
     fail_if(hy_goal_install(goal, pkg));
-    fail_unless(hy_goal_has_actions(goal, HY_INSTALL));
+    fail_unless(hy_goal_has_actions(goal, HIF_INSTALL));
     g_object_unref(pkg);
     hy_goal_free(goal);
 }
@@ -307,7 +307,7 @@ START_TEST(test_goal_install_weak_deps)
     // recommended package C is installed too
     assert_iueo(goal, 2, 0, 0, 0);
 
-    fail_if(hy_goal_run_flags(goal2, HY_IGNORE_WEAK_DEPS));
+    fail_if(hy_goal_run_flags(goal2, HIF_IGNORE_WEAK_DEPS));
     assert_iueo(goal2, 1, 0, 0, 0);
     hy_goal_free(goal);
     hy_goal_free(goal2);
@@ -640,7 +640,7 @@ START_TEST(test_goal_erase_with_deps)
 
     goal = hy_goal_create(sack);
     hy_goal_erase(goal, pkg);
-    fail_if(hy_goal_run_flags(goal, HY_ALLOW_UNINSTALL));
+    fail_if(hy_goal_run_flags(goal, HIF_ALLOW_UNINSTALL));
     assert_iueo(goal, 0, 0, 2, 0);
     hy_goal_free(goal);
 
@@ -691,7 +691,7 @@ START_TEST(test_goal_forcebest)
 
     hy_selector_set(sltr, HY_PKG_NAME, HY_EQ, "flying");
     hy_goal_upgrade_selector(goal, sltr);
-    fail_unless(hy_goal_run_flags(goal, HY_FORCE_BEST));
+    fail_unless(hy_goal_run_flags(goal, HIF_FORCE_BEST));
     fail_unless(hy_goal_count_problems(goal) == 1);
 
     hy_selector_free(sltr);
@@ -705,7 +705,7 @@ START_TEST(test_goal_verify)
     HifSack *sack = test_globals.sack;
     HyGoal goal = hy_goal_create(sack);
 
-    fail_unless(hy_goal_run_flags(goal, HY_VERIFY));
+    fail_unless(hy_goal_run_flags(goal, HIF_VERIFY));
     fail_unless(hy_goal_list_installs(goal, &error) == NULL);
     fail_unless(error->code == HIF_ERROR_NO_SOLUTION);
     fail_unless(hy_goal_count_problems(goal) == 2);
@@ -1182,7 +1182,7 @@ START_TEST(test_goal_forcebest_arches)
 
     hy_selector_set(sltr, HY_PKG_NAME, HY_EQ, "gun");
     fail_if(hy_goal_upgrade_selector(goal, sltr));
-    fail_if(hy_goal_run_flags(goal, HY_FORCE_BEST));
+    fail_if(hy_goal_run_flags(goal, HIF_FORCE_BEST));
     assert_iueo(goal, 0, 0, 0, 0);
 
     hy_selector_free(sltr);
@@ -1232,7 +1232,7 @@ START_TEST(test_cmdline_file_provides)
     HyGoal goal = hy_goal_create(sack);
 
     hy_goal_upgrade_all(goal);
-    ck_assert(!hy_goal_run_flags(goal, HY_FORCE_BEST));
+    ck_assert(!hy_goal_run_flags(goal, HIF_FORCE_BEST));
     assert_iueo(goal, 0, 1, 0, 0);
     hy_goal_free(goal);
 }


### PR DESCRIPTION
needed for https://github.com/rpm-software-management/dnf/pull/443

a413e3e breaks ABI - it was unfortunately exposed recently. Have you done the build of new libhif for rpm-ostree yet, @cgwalters ? I could rework that if we have libhif already released.