### PR TITLE
Initial stub travis.yml just for Homu

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,16 @@
+# We're just using a "stubbed out" Travis right now so we can
+# use Homu <https://github.com/barosl/homu> to auto-squash
+# etc.
+# @jsilhan suggested pulling down a Fedora docker image as
+# a tester.
+language: c
+install: true
+script: test '!' -f broken.txt
+
+notifications:
+  webhooks: http://escher.verbum.org:54856/travis
+  email: false
+
+branches:
+  only:
+    - auto


### PR DESCRIPTION
Everyone on this project expressed a dislike for the Github merge
commits etc.  Homu fixes that by implementing an auto-squashing (it
also supports `--fixup` which is awesome).

So initially, our travis test is basically just a stub.  We can expand
this in the future, or alternatively investigate a custom Jenkins
instance (which is my preference as opposed to relying on proprietary
infrastructure too much).