### PR TITLE
Set operations on hawkey queries

### DIFF
--- a/libhif/hy-query.c
+++ b/libhif/hy-query.c
@@ -1359,3 +1359,49 @@ hy_query_run_set(HyQuery q)
     hy_query_apply(q);
     return hif_packageset_from_bitmap(q->sack, q->result);
 }
+
+/**
+ * hy_query_union:
+ * @q:     a #HyQuery instance
+ * @other: other #HyQuery instance
+ *
+ * Unites query with other query (aka logical or).
+ *
+ */
+void
+hy_query_union(HyQuery q, HyQuery other)
+{
+    hy_query_apply(q);
+    hy_query_apply(other);
+    map_or(q->result, other->result);
+}
+
+/**
+ * hy_query_intersection:
+ * @q:     a #HyQuery instance
+ * @other: other #HyQuery instance
+ *
+ * Intersects query with other query (aka logical and).
+ */
+void
+hy_query_intersection(HyQuery q, HyQuery other)
+{
+    hy_query_apply(q);
+    hy_query_apply(other);
+    map_and(q->result, other->result);
+}
+
+/**
+ * hy_query_difference:
+ * @q:     a #HyQuery instance
+ * @other: other #HyQuery instance
+ *
+ * Computes difference between query and other query (aka q and not other).
+ */
+void
+hy_query_difference(HyQuery q, HyQuery other)
+{
+    hy_query_apply(q);
+    hy_query_apply(other);
+    map_subtract(q->result, other->result);
+}

--- a/libhif/hy-query.h
+++ b/libhif/hy-query.h
@@ -91,6 +91,9 @@ void hy_query_filter_latest(HyQuery q, int val);
 GPtrArray *hy_query_run(HyQuery q);
 HifPackageSet *hy_query_run_set(HyQuery q);
 
+void hy_query_union(HyQuery q, HyQuery other);
+void hy_query_intersection(HyQuery q, HyQuery other);
+void hy_query_difference(HyQuery q, HyQuery other);
 
 G_END_DECLS
 

--- a/python/hawkey/__init__.py
+++ b/python/hawkey/__init__.py
@@ -306,9 +306,6 @@ class Query(_hawkey.Query):
     def __getitem__(self, idx):
         return self.run()[idx]
 
-    def __len__(self):
-        return len(self.run())
-
     def count(self):
         return len(self)
 

--- a/python/hawkey/__init__.py
+++ b/python/hawkey/__init__.py
@@ -343,6 +343,17 @@ class Query(_hawkey.Query):
         raise NotImplementedError(
             "hawkey.Query.provides is not implemented yet")
 
+    def difference(self, other):
+        new_query = type(self)(query=self)
+        return super(Query, new_query).difference(other)
+
+    def intersection(self, other):
+        new_query = type(self)(query=self)
+        return super(Query, new_query).intersection(other)
+
+    def union(self, other):
+        new_query = type(self)(query=self)
+        return super(Query, new_query).union(other)
 
 class Selector(_hawkey.Selector):
 

--- a/python/hawkey/query-py.c
+++ b/python/hawkey/query-py.c
@@ -365,6 +365,22 @@ q_contains(PyObject *self, PyObject *pypkg)
     Py_RETURN_FALSE;
 }
 
+static PyObject *
+q_length(PyObject *self, PyObject *unused)
+{
+    HyQuery q = ((_QueryObject *) self)->query;
+    hy_query_apply(q);
+
+    unsigned char *res = q->result->map;
+    unsigned char *end = res + q->result->size;
+    int length = 0;
+
+    while (res < end)
+        length += __builtin_popcount(*res++);
+
+    return PyLong_FromLong(length);
+}
+
 static struct PyMethodDef query_methods[] = {
     {"clear", (PyCFunction)clear, METH_NOARGS,
      NULL},
@@ -381,6 +397,8 @@ static struct PyMethodDef query_methods[] = {
     {"difference", (PyCFunction)q_difference, METH_O,
      NULL},
     {"__contains__", (PyCFunction)q_contains, METH_O,
+     NULL},
+    {"__len__", (PyCFunction)q_length, METH_NOARGS,
      NULL},
     {NULL}                      /* sentinel */
 };

--- a/python/hawkey/query-py.c
+++ b/python/hawkey/query-py.c
@@ -319,6 +319,36 @@ apply(PyObject *self, PyObject *unused)
     return self;
 }
 
+static PyObject *
+q_union(PyObject *self, PyObject *other)
+{
+    HyQuery self_q = ((_QueryObject *) self)->query;
+    HyQuery other_q = ((_QueryObject *) other)->query;
+    hy_query_union(self_q, other_q);
+    Py_INCREF(self);
+    return self;
+}
+
+static PyObject *
+q_intersection(PyObject *self, PyObject *other)
+{
+    HyQuery self_q = ((_QueryObject *) self)->query;
+    HyQuery other_q = ((_QueryObject *) other)->query;
+    hy_query_intersection(self_q, other_q);
+    Py_INCREF(self);
+    return self;
+}
+
+static PyObject *
+q_difference(PyObject *self, PyObject *other)
+{
+    HyQuery self_q = ((_QueryObject *) self)->query;
+    HyQuery other_q = ((_QueryObject *) other)->query;
+    hy_query_difference(self_q, other_q);
+    Py_INCREF(self);
+    return self;
+}
+
 static struct PyMethodDef query_methods[] = {
     {"clear", (PyCFunction)clear, METH_NOARGS,
      NULL},
@@ -327,6 +357,12 @@ static struct PyMethodDef query_methods[] = {
     {"run", (PyCFunction)run, METH_NOARGS,
      NULL},
     {"apply", (PyCFunction)apply, METH_NOARGS,
+     NULL},
+    {"union", (PyCFunction)q_union, METH_O,
+     NULL},
+    {"intersection", (PyCFunction)q_intersection, METH_O,
+     NULL},
+    {"difference", (PyCFunction)q_difference, METH_O,
      NULL},
     {NULL}                      /* sentinel */
 };

--- a/python/hawkey/query-py.c
+++ b/python/hawkey/query-py.c
@@ -21,6 +21,7 @@
 #include <Python.h>
 #include <solv/util.h>
 
+#include "hy-package-private.h"
 #include "hy-packageset-private.h"
 #include "hy-query-private.h"
 #include "hif-reldep.h"
@@ -349,6 +350,21 @@ q_difference(PyObject *self, PyObject *other)
     return self;
 }
 
+static PyObject *
+q_contains(PyObject *self, PyObject *pypkg)
+{
+    HyQuery q = ((_QueryObject *) self)->query;
+    HifPackage *pkg = packageFromPyObject(pypkg);
+
+    if (pkg) {
+        Id id = hif_package_get_id(pkg);
+        hy_query_apply(q);
+        if (MAPTST(q->result, id))
+            Py_RETURN_TRUE;
+    }
+    Py_RETURN_FALSE;
+}
+
 static struct PyMethodDef query_methods[] = {
     {"clear", (PyCFunction)clear, METH_NOARGS,
      NULL},
@@ -363,6 +379,8 @@ static struct PyMethodDef query_methods[] = {
     {"intersection", (PyCFunction)q_intersection, METH_O,
      NULL},
     {"difference", (PyCFunction)q_difference, METH_O,
+     NULL},
+    {"__contains__", (PyCFunction)q_contains, METH_O,
      NULL},
     {NULL}                      /* sentinel */
 };

--- a/tests/hawkey/test_query.c
+++ b/tests/hawkey/test_query.c
@@ -1035,6 +1035,54 @@ START_TEST(test_filter_advisory_bug)
 }
 END_TEST
 
+START_TEST(test_difference)
+{
+    HyQuery q1 = hy_query_create(test_globals.sack);
+    hy_query_filter(q1, HY_PKG_VERSION, HY_EQ, "4");
+    HyQuery q2 = hy_query_create(test_globals.sack);
+    hy_query_filter(q2, HY_PKG_NAME, HY_GLOB, "p*");
+
+    hy_query_difference(q1, q2);
+    GPtrArray *plist = hy_query_run(q1);
+    fail_unless(plist->len == 2);
+    hy_query_free(q2);
+    hy_query_free(q1);
+    g_ptr_array_unref(plist);
+}
+END_TEST
+
+START_TEST(test_intersection)
+{
+    HyQuery q1 = hy_query_create(test_globals.sack);
+    hy_query_filter(q1, HY_PKG_VERSION, HY_EQ, "4");
+    HyQuery q2 = hy_query_create(test_globals.sack);
+    hy_query_filter(q2, HY_PKG_NAME, HY_GLOB, "p*");
+
+    hy_query_intersection(q1, q2);
+    GPtrArray *plist = hy_query_run(q1);
+    fail_unless(plist->len == 7);
+    hy_query_free(q2);
+    hy_query_free(q1);
+    g_ptr_array_unref(plist);
+}
+END_TEST
+
+START_TEST(test_union)
+{
+    HyQuery q1 = hy_query_create(test_globals.sack);
+    hy_query_filter(q1, HY_PKG_VERSION, HY_EQ, "4");
+    HyQuery q2 = hy_query_create(test_globals.sack);
+    hy_query_filter(q2, HY_PKG_NAME, HY_GLOB, "p*");
+
+    hy_query_union(q1, q2);
+    GPtrArray *plist = hy_query_run(q1);
+    fail_unless(plist->len == 11);
+    hy_query_free(q2);
+    hy_query_free(q1);
+    g_ptr_array_unref(plist);
+}
+END_TEST
+
 Suite *
 query_suite(void)
 {
@@ -1125,6 +1173,13 @@ query_suite(void)
     tcase_add_test(tc, test_filter_advisory_type);
     tcase_add_test(tc, test_filter_advisory_cve);
     tcase_add_test(tc, test_filter_advisory_bug);
+
+    tc = tcase_create("Set Operations");
+    tcase_add_unchecked_fixture(tc, fixture_with_main, teardown);
+    tcase_add_test(tc, test_difference);
+    tcase_add_test(tc, test_intersection);
+    tcase_add_test(tc, test_union);
+
     suite_add_tcase(s, tc);
 
     return s;


### PR DESCRIPTION
Makes easy operations as merge two queries (aka union) filter one query with another (aka intersection) and query differences.

All above can be achieved with current code but in a much complicated and slower way, e.g. currently we  do
pkgs = q1.run() + q2.run()
q = sack.query().filter(pkg=pkgs)
and there already are couple of places in dnf code where we do the above.