### PR TITLE
[merged] hif_context: add hif_context_set_source_root()

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -142,7 +142,6 @@ hif_context_init(HifContext *context)
 {
     HifContextPrivate *priv = GET_PRIVATE(context);
     priv->install_root = g_strdup("/");
-    priv->source_root = g_strdup("/");
     priv->check_disk_space = TRUE;
     priv->check_transaction = TRUE;
     priv->enable_yumdb = TRUE;
@@ -354,7 +353,7 @@ const gchar *
 hif_context_get_source_root(HifContext *context)
 {
     HifContextPrivate *priv = GET_PRIVATE(context);
-    return priv->source_root;
+    return priv->source_root != NULL ? priv->source_root : priv->install_root;
 }
 
 /**
@@ -897,11 +896,12 @@ hif_context_set_os_release(HifContext *context, GError **error)
     g_autofree gchar *os_release = NULL;
     g_autoptr(GString) str = NULL;
     g_autoptr(GKeyFile) key_file = NULL;
+    const char *source_root = hif_context_get_source_root(context);
 
-    os_release = g_build_filename(priv->source_root, "etc/os-release", NULL);
+    os_release = g_build_filename(source_root, "etc/os-release", NULL);
     if (!g_file_get_contents(os_release, &contents, NULL, NULL)) {
         g_free (os_release);
-        os_release = g_build_filename(priv->source_root, "usr/lib/os-release", NULL);
+        os_release = g_build_filename(source_root, "usr/lib/os-release", NULL);
         if (!g_file_get_contents(os_release, &contents, NULL, NULL))
             return FALSE;
     }

--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -903,7 +903,7 @@ hif_context_set_os_release(HifContext *context, GError **error)
         g_free (os_release);
         os_release = g_build_filename(priv->source_root, "usr/lib/os-release", NULL);
         if (!g_file_get_contents(os_release, &contents, NULL, NULL))
-          return FALSE;
+            return FALSE;
     }
 
     str = g_string_new(contents);

--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -58,6 +58,7 @@ typedef struct
     gchar            *os_info;
     gchar            *arch_info;
     gchar            *install_root;
+    gchar            *source_root;
     gchar            *rpm_verbosity;
     gchar            **native_arches;
     gchar            *http_proxy;
@@ -110,6 +111,7 @@ hif_context_finalize(GObject *object)
     g_free(priv->lock_dir);
     g_free(priv->rpm_verbosity);
     g_free(priv->install_root);
+    g_free(priv->source_root);
     g_free(priv->os_info);
     g_free(priv->arch_info);
     g_free(priv->http_proxy);
@@ -140,6 +142,7 @@ hif_context_init(HifContext *context)
 {
     HifContextPrivate *priv = GET_PRIVATE(context);
     priv->install_root = g_strdup("/");
+    priv->source_root = g_strdup("/");
     priv->check_disk_space = TRUE;
     priv->check_transaction = TRUE;
     priv->enable_yumdb = TRUE;
@@ -335,6 +338,23 @@ hif_context_get_install_root(HifContext *context)
 {
     HifContextPrivate *priv = GET_PRIVATE(context);
     return priv->install_root;
+}
+
+/**
+ * hif_context_get_source_root:
+ * @context: a #HifContext instance.
+ *
+ * Gets the source root, by default "/".
+ *
+ * Returns: the source root, e.g. "/tmp/my_os"
+ *
+ * Since: 0.1.0
+ **/
+const gchar *
+hif_context_get_source_root(HifContext *context)
+{
+    HifContextPrivate *priv = GET_PRIVATE(context);
+    return priv->source_root;
 }
 
 /**
@@ -751,6 +771,23 @@ hif_context_set_install_root(HifContext *context, const gchar *install_root)
 }
 
 /**
+ * hif_context_set_source_root:
+ * @context: a #HifContext instance.
+ * @source_root: the source root, e.g. "/"
+ *
+ * Sets the source root to use for retrieving system information.
+ *
+ * Since: 0.1.0
+ **/
+void
+hif_context_set_source_root(HifContext *context, const gchar *source_root)
+{
+    HifContextPrivate *priv = GET_PRIVATE(context);
+    g_free(priv->source_root);
+    priv->source_root = g_strdup(source_root);
+}
+
+/**
  * hif_context_set_check_disk_space:
  * @context: a #HifContext instance.
  * @check_disk_space: %TRUE to check for diskspace
@@ -854,16 +891,26 @@ hif_context_set_cache_age(HifContext *context, guint cache_age)
 static gboolean
 hif_context_set_os_release(HifContext *context, GError **error)
 {
+    HifContextPrivate *priv = GET_PRIVATE(context);
     g_autofree gchar *contents = NULL;
     g_autofree gchar *version = NULL;
+    g_autofree gchar *os_release = NULL;
     g_autoptr(GString) str = NULL;
     g_autoptr(GKeyFile) key_file = NULL;
 
-    /* make a valid GKeyFile from the .ini data by prepending a header */
-    if (!g_file_get_contents("/etc/os-release", &contents, NULL, NULL))
-        return FALSE;
+    os_release = g_build_filename(priv->source_root, "etc/os-release", NULL);
+    if (!g_file_get_contents(os_release, &contents, NULL, NULL)) {
+        g_free (os_release);
+        os_release = g_build_filename(priv->source_root, "usr/lib/os-release", NULL);
+        if (!g_file_get_contents(os_release, &contents, NULL, NULL))
+          return FALSE;
+    }
+
     str = g_string_new(contents);
+
+    /* make a valid GKeyFile from the .ini data by prepending a header */
     g_string_prepend(str, "[os-release]\n");
+
     key_file = g_key_file_new();
     if (!g_key_file_load_from_data(key_file,
                      str->str, -1,

--- a/libhif/hif-context.h
+++ b/libhif/hif-context.h
@@ -79,6 +79,7 @@ const gchar     *hif_context_get_solv_dir               (HifContext     *context
 const gchar     *hif_context_get_lock_dir               (HifContext     *context);
 const gchar     *hif_context_get_rpm_verbosity          (HifContext     *context);
 const gchar     *hif_context_get_install_root           (HifContext     *context);
+const gchar     *hif_context_get_source_root            (HifContext     *context);
 const gchar     **hif_context_get_native_arches         (HifContext     *context);
 const gchar     **hif_context_get_installonly_pkgs      (HifContext     *context);
 gboolean         hif_context_get_check_disk_space       (HifContext     *context);
@@ -116,6 +117,8 @@ void             hif_context_set_rpm_verbosity          (HifContext     *context
                                                          const gchar    *rpm_verbosity);
 void             hif_context_set_install_root           (HifContext     *context,
                                                          const gchar    *install_root);
+void             hif_context_set_source_root            (HifContext     *context,
+                                                         const gchar    *source_root);
 void             hif_context_set_check_disk_space       (HifContext     *context,
                                                          gboolean        check_disk_space);
 void             hif_context_set_check_transaction      (HifContext     *context,


### PR DESCRIPTION
For now, `source_root` is only used for retrieving `os-release`. This is
useful for OSTree, which can have multiple OS roots.

Also, fallback to `/usr/lib/os-releas`e if `/etc/os-release` doesn't exist:
https://www.freedesktop.org/software/systemd/man/os-release.html