### PR TITLE
sack: Remove bogus assertion in exclude processing

### DIFF
--- a/libhif/hif-sack.c
+++ b/libhif/hif-sack.c
@@ -1150,7 +1150,6 @@ hif_sack_add_excludes(HifSack *sack, HifPackageSet *pset)
         map_init(excl, pool->nsolvables);
         priv->pkg_excludes = excl;
     }
-    assert(excl->size >= nexcl->size);
     map_or(excl, nexcl);
     priv->considered_uptodate = FALSE;
 }


### PR DESCRIPTION
It turns out that hawkey by default commonly compiled without
assertions enabled, which means they were rarely tested.  This
assertion is definitely bogus, because looking at the source to
`map_or`, it will grow the target if it's smaller than the source.

This is a followup to
https://github.com/rpm-software-management/libhif/pull/83