### PR TITLE
add .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+
+[*.[ch]]
+indent_style = space
+indent_size = 4
+trim_trailing_whitespace = true

--- a/libhif.doap
+++ b/libhif.doap
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#"
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+         xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+  <Project rdf:about="https://github.com/rpm-software-management/libhif">
+    <name>util-linux</name>
+    <homepage rdf:resource="https://github.com/rpm-software-management/libhif" />
+    <shortdesc>
+       Simple package manager
+    </shortdesc>
+    <description>
+      This library provides a high level package-manager.
+      It uses librepo, libsolv and other libraries under the hood.
+    </description>
+    <bug-database rdf:resource="https://github.com/rpm-software-management/libhif/issues" />
+    <mailing-list rdf:resource="http://lists.rpm.org/mailman/listinfo/rpm-ecosystem" />
+    <download-page rdf:resource="https://github.com/rpm-software-management/libhif/releases" />
+    <programming-language>C</programming-language>
+    <repository>
+      <GitRepository>
+        <location rdf:resource="git://github.com/rpm-software-management/libhif.git"/>
+        <browse rdf:resource="https://github.com/rpm-software-management/libhif"/>
+      </GitRepository>
+    </repository>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Richard Hughsie</foaf:name>
+        <foaf:mbox rdf:resource="mailto:rhughes@redhat.com" />
+      </foaf:Person>
+    </maintainer>
+  </Project>
+</rdf:RDF>

--- a/libhif.doap
+++ b/libhif.doap
@@ -5,7 +5,7 @@
          xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
          xmlns:foaf="http://xmlns.com/foaf/0.1/">
   <Project rdf:about="https://github.com/rpm-software-management/libhif">
-    <name>util-linux</name>
+    <name>libhif</name>
     <homepage rdf:resource="https://github.com/rpm-software-management/libhif" />
     <shortdesc>
        Simple package manager
@@ -26,7 +26,7 @@
     </repository>
     <maintainer>
       <foaf:Person>
-        <foaf:name>Richard Hughsie</foaf:name>
+        <foaf:name>Richard Hughes</foaf:name>
         <foaf:mbox rdf:resource="mailto:rhughes@redhat.com" />
       </foaf:Person>
     </maintainer>


### PR DESCRIPTION
EditorConfig is very well known config file for text editors/IDE's
with settings for project. This format supported by Vim, GNOME Builder,
Atom, Sublime and many others.

We will provide this configuration to be more friendly for newcomers.

Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>