### PR TITLE
build: Install hif-enums.h

### DIFF
--- a/libhif/CMakeLists.txt
+++ b/libhif/CMakeLists.txt
@@ -82,6 +82,7 @@ SET(LIBHIF_headers
     hif-advisorypkg.h
     hif-advisoryref.h
     hif-context.h
+    hif-enums.h
     hif-db.h
     hif-goal.h
     hif-keyring.h


### PR DESCRIPTION
This is a regression from 72cf2bce90931fe6a5f4aa43901480a89c6c282d
where the header was introduced, and other public headers
depend on it.

Without this, dependent C projects like rpm-ostree will fail to build.