### PR TITLE
[merged] query: Add hy_autoquery

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -1598,7 +1598,7 @@ hif_context_install (HifContext *context, const gchar *name, GError **error)
     HifContextPrivate *priv = GET_PRIVATE (context);
     g_autoptr(GPtrArray) pkglist = NULL;
     HifPackage *pkg;
-    HyQuery query;
+    hy_autoquery HyQuery query = NULL;
     gboolean ret = TRUE;
 
     /* create sack and add sources */
@@ -1633,7 +1633,6 @@ hif_context_install (HifContext *context, const gchar *name, GError **error)
     g_debug("adding %s-%s to goal", hif_package_get_name(pkg), hif_package_get_evr(pkg));
     hy_goal_install(priv->goal, pkg);
 
-    hy_query_free(query);
     return TRUE;
 }
 
@@ -1657,7 +1656,7 @@ hif_context_remove(HifContext *context, const gchar *name, GError **error)
     HifContextPrivate *priv = GET_PRIVATE(context);
     GPtrArray *pkglist;
     HifPackage *pkg;
-    HyQuery query;
+    hy_autoquery HyQuery query = NULL;
     gboolean ret = TRUE;
     guint i;
 
@@ -1684,7 +1683,6 @@ hif_context_remove(HifContext *context, const gchar *name, GError **error)
         hy_goal_erase(priv->goal, pkg);
     }
     g_ptr_array_unref(pkglist);
-    hy_query_free(query);
     return TRUE;
 }
 
@@ -1708,7 +1706,7 @@ hif_context_update(HifContext *context, const gchar *name, GError **error)
     HifContextPrivate *priv = GET_PRIVATE(context);
     GPtrArray *pkglist;
     HifPackage *pkg;
-    HyQuery query;
+    hy_autoquery HyQuery query = NULL;
     gboolean ret = TRUE;
     guint i;
 
@@ -1740,7 +1738,6 @@ hif_context_update(HifContext *context, const gchar *name, GError **error)
             hy_goal_upgrade_to(priv->goal, pkg);
     }
     g_ptr_array_unref(pkglist);
-    hy_query_free(query);
     return TRUE;
 }
 

--- a/libhif/hy-query.h
+++ b/libhif/hy-query.h
@@ -34,6 +34,8 @@ enum _hy_query_flags {
     HY_IGNORE_EXCLUDES        = 1 << 0
 };
 
+#define hy_autoquery __attribute__ ((cleanup(hy_query_autofree)))
+
 void hy_query_apply(HyQuery q);
 HyQuery hy_query_create(HifSack *sack);
 HyQuery hy_query_create_flags(HifSack *sack, int flags);
@@ -94,6 +96,15 @@ HifPackageSet *hy_query_run_set(HyQuery q);
 void hy_query_union(HyQuery q, HyQuery other);
 void hy_query_intersection(HyQuery q, HyQuery other);
 void hy_query_difference(HyQuery q, HyQuery other);
+
+static inline void
+hy_query_autofree (void *v)
+{
+  HyQuery *pp = (HyQuery*)v;
+  HyQuery query = *pp;
+  if (query)
+    hy_query_free (query);
+}
 
 G_END_DECLS
 


### PR DESCRIPTION
What we really should do is convert this to a GObject or a boxed
type - but that would conflict with a few outstanding PRs.

This patch adds an autocleanup, and uses it in HifContext, which
incidentally fixes memory leaks in error paths.

I'm mainly writing this because I was about to add new code using
HyQuery, and the leaks were bugging me.