### PR TITLE
[merged] sack: trigger repo internalizing if cmdline pkg is added into sack + sourcerpm

### DIFF
--- a/libhif/hif-sack.c
+++ b/libhif/hif-sack.c
@@ -1107,6 +1107,8 @@ hif_sack_add_cmdline_package(HifSack *sack, const char *fn)
         return NULL;
     }
     p = repo_add_rpm(repo, fn, REPO_REUSE_REPODATA|REPO_NO_INTERNALIZE);
+    HyRepo hrepo = repo->appdata;
+    hrepo->needs_internalizing = 1;
     priv->provides_ready = 0;    /* triggers internalizing later */
     return hif_package_new(sack, p);
 }

--- a/libhif/hy-package.c
+++ b/libhif/hy-package.c
@@ -391,6 +391,7 @@ char *
 hif_package_get_sourcerpm(HifPackage *pkg)
 {
     Solvable *s = get_solvable(pkg);
+    repo_internalize_trigger(s->repo);
     return g_strdup(solvable_lookup_sourcepkg(s));
 }
 

--- a/python/hawkey/tests/tests/test_package.py
+++ b/python/hawkey/tests/tests/test_package.py
@@ -177,3 +177,6 @@ class FullPropertiesTest(base.TestCase):
 
     def test_hdr_end(self):
         self.assertEqual(self.pkg.hdr_end, 2081)
+
+    def test_sourcerpm(self):
+        self.assertEqual(self.pkg.sourcerpm, 'mystery-19.67-1.src.rpm')

--- a/tests/hawkey/test_sack.c
+++ b/tests/hawkey/test_sack.c
@@ -129,6 +129,29 @@ START_TEST(test_repo_written)
 }
 END_TEST
 
+START_TEST(test_add_cmdline_package)
+{
+    HifSack *sack = hif_sack_new();
+    hif_sack_set_cachedir(sack, test_globals.tmpdir);
+
+    char *path_mystery = solv_dupjoin(TESTDATADIR, "/hawkey/yum/mystery-devel-19.67-1.noarch.rpm", NULL);
+    HifPackage *pkg_mystery = hif_sack_add_cmdline_package(sack, path_mystery);
+    char *location_mystery = hif_package_get_location(pkg_mystery);
+    ck_assert_str_eq(path_mystery, location_mystery);
+
+    char *path_tour = solv_dupjoin(TESTDATADIR, "/hawkey/yum/tour-4-6.noarch.rpm", NULL);
+    HifPackage *pkg_tour = hif_sack_add_cmdline_package(sack, path_tour);
+    char *location_tour = hif_package_get_location(pkg_tour);
+    ck_assert_str_eq(path_tour, location_tour);
+
+    g_free(path_mystery);
+    g_free(location_mystery);
+    g_free(path_tour);
+    g_free(location_tour);
+    g_object_unref(sack);
+}
+END_TEST
+
 START_TEST(test_repo_load)
 {
     fail_unless(hif_sack_count(test_globals.sack) ==
@@ -282,6 +305,7 @@ sack_suite(void)
     tcase_add_test(tc, test_list_arches);
     tcase_add_test(tc, test_load_repo_err);
     tcase_add_test(tc, test_repo_written);
+    tcase_add_test(tc, test_add_cmdline_package);
     suite_add_tcase(s, tc);
 
     tc = tcase_create("Repos");


### PR DESCRIPTION
fixing:
```
d = dnf.base.Base(...)
d.fill_sack(load_system_repo=False, load_available_repos=False)

pkg = d.add_remote_rpm()
print pkg.location
> /path/to/rpm
pkg = d.add_remote_rpm()
print pkg.location
> None
```
and
```
pkg = d.add_remote_rpm(<path>)
print(pkg.sourcerpm)
> None
```

includes #115