### PR TITLE
[merged] gir: gir version should match so version

### DIFF
--- a/libhif/CMakeLists.txt
+++ b/libhif/CMakeLists.txt
@@ -133,7 +133,7 @@ if (GOBJECT_INTROSPECTION_FOUND)
         add_custom_command(OUTPUT ${GIR_XML}
             COMMAND ${GOBJECT_INTROSPECTION_1.0_G_IR_SCANNER}
                     --namespace=Hif
-                    --nsversion=${HIF_SO_VERSION}
+                    --nsversion=${HIF_SO_VERSION}.0
                     --library-path=${CMAKE_CURRENT_BINARY_DIR}
                     --library=hif
                     --no-libtool


### PR DESCRIPTION
```
import gi
gi.require_version('Hif', '3.0')
from gi.repository import Hif
```

```
 File "/home/mluscon/projects/dnf/dnf/base.py", line 37, in <module>
    from gi.repository import Hif
  File "<frozen importlib._bootstrap>", line 2237, in _find_and_load
  File "<frozen importlib._bootstrap>", line 2226, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 1191, in _load_unlocked
  File "<frozen importlib._bootstrap>", line 1161, in _load_backward_compatible
  File "/usr/lib64/python3.4/site-packages/gi/importer.py", line 114, in load_module
    introspection_module = get_introspection_module(namespace)
  File "/usr/lib64/python3.4/site-packages/gi/module.py", line 271, in get_introspection_module
    module = IntrospectionModule(namespace, version)
  File "/usr/lib64/python3.4/site-packages/gi/module.py", line 120, in __init__
    repository.require(namespace, version)
gi.RepositoryError: Typelib file /usr/lib64/girepository-1.0/Hif-3.0.typelib for namespace 'Hif' contains version '3' which doesn't match the expected version '3.0'
```