### PR TITLE
[merged] Correctly set yumdb "reason" when updating / installing packages

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -1629,7 +1629,6 @@ hif_context_install (HifContext *context, const gchar *name, GError **error)
 
     /* add first package */
     pkg = g_ptr_array_index (pkglist, 0);
-    hif_package_set_user_action(pkg, TRUE);
     g_debug("adding %s-%s to goal", hif_package_get_name(pkg), hif_package_get_evr(pkg));
     hy_goal_install(priv->goal, pkg);
 
@@ -1680,7 +1679,6 @@ hif_context_remove(HifContext *context, const gchar *name, GError **error)
     /* add each package */
     for (i = 0; i < pkglist->len; i++) {
         pkg = g_ptr_array_index (pkglist, i);
-        hif_package_set_user_action(pkg, TRUE);
         hy_goal_erase(priv->goal, pkg);
     }
     g_ptr_array_unref(pkglist);
@@ -1733,7 +1731,6 @@ hif_context_update(HifContext *context, const gchar *name, GError **error)
     /* add each package */
     for (i = 0; i < pkglist->len; i++) {
         pkg = g_ptr_array_index (pkglist, i);
-        hif_package_set_user_action(pkg, TRUE);
         if (hif_package_is_installonly(pkg))
             hy_goal_install(priv->goal, pkg);
         else

--- a/libhif/hif-db.c
+++ b/libhif/hif-db.c
@@ -172,7 +172,7 @@ hif_db_get_string(HifDb *db, HifPackage *package, const gchar *key, GError **err
         g_set_error(error,
                     HIF_ERROR,
                     HIF_ERROR_FAILED,
-                    "cannot create index for %s",
+                    "cannot read index for %s",
                     hif_package_get_package_id(package));
         return NULL;
     }

--- a/libhif/hif-transaction.c
+++ b/libhif/hif-transaction.c
@@ -71,6 +71,7 @@ typedef struct
     GPtrArray           *remove_helper;
     GPtrArray           *install;
     GPtrArray           *pkgs_to_download;
+    GHashTable          *erased_by_package_hash;
     guint64             flags;
 } HifTransactionPrivate;
 
@@ -101,6 +102,8 @@ hif_transaction_finalize(GObject *object)
         g_ptr_array_unref(priv->remove);
     if (priv->remove_helper != NULL)
         g_ptr_array_unref(priv->remove_helper);
+    if (priv->erased_by_package_hash != NULL)
+        g_hash_table_unref(priv->erased_by_package_hash);
     if (priv->context != NULL)
         g_object_remove_weak_pointer(G_OBJECT(priv->context),
                                      (void **) &priv->context);
@@ -886,6 +889,48 @@ hif_transaction_delete_packages(HifTransaction *transaction,
     return TRUE;
 }
 
+static gchar *
+hif_transaction_get_propagated_reason(HifTransaction *transaction,
+                                      HyGoal goal,
+                                      HifPackage *pkg)
+{
+    HifTransactionPrivate *priv = GET_PRIVATE(transaction);
+
+    /* kernel is always marked as "user" */
+    if (hif_package_is_installonly(pkg))
+        return g_strdup("user");
+
+    /* for updates, propagate updated package's reason from existing yumdb entry */
+    if (hif_package_get_action(pkg) == HIF_STATE_ACTION_DOWNGRADE ||
+        hif_package_get_action(pkg) == HIF_STATE_ACTION_REINSTALL ||
+        hif_package_get_action(pkg) == HIF_STATE_ACTION_UPDATE) {
+        HifPackage *erased_package;
+
+        erased_package = g_hash_table_lookup(priv->erased_by_package_hash, hif_package_get_package_id(pkg));
+        if (erased_package != NULL) {
+            gchar *reason;
+
+            reason = hif_db_get_string(priv->db, erased_package, "reason", NULL);
+            if (reason != NULL) {
+                g_debug("propagating yumdb reason %s from %s to %s",
+                        reason,
+                        hif_package_get_package_id(erased_package),
+                        hif_package_get_package_id(pkg));
+                return reason;
+            }
+        }
+        return g_strdup("dep");
+    }
+
+    /* for non-upgrades, packages explicitly passed to hawkey for
+     * installation get "user" and dependencies it adds on its own get
+     * "dep" */
+    if (hy_goal_get_reason(goal, pkg) == HY_REASON_USER)
+        return g_strdup("user");
+    else
+        return g_strdup("dep");
+}
+
 /**
  * hif_transaction_write_yumdb_install_item:
  *
@@ -894,6 +939,7 @@ hif_transaction_delete_packages(HifTransaction *transaction,
  **/
 static gboolean
 hif_transaction_write_yumdb_install_item(HifTransaction *transaction,
+                                         HyGoal goal,
                                          HifPackage *pkg,
                                          HifState *state,
                                          GError **error)
@@ -901,6 +947,7 @@ hif_transaction_write_yumdb_install_item(HifTransaction *transaction,
     HifTransactionPrivate *priv = GET_PRIVATE(transaction);
     const gchar *tmp;
     g_autofree gchar *euid = NULL;
+    g_autofree gchar *reason = NULL;
 
     /* should be set by hif_transaction_ts_progress_cb() */
     if (hif_package_get_pkgid(pkg) == NULL) {
@@ -926,13 +973,9 @@ hif_transaction_write_yumdb_install_item(HifTransaction *transaction,
         return FALSE;
 
     /* set the correct reason */
-    if (hif_package_get_user_action(pkg)) {
-        if (!hif_db_set_string(priv->db, pkg, "reason", "user", error))
-            return FALSE;
-    } else {
-        if (!hif_db_set_string(priv->db, pkg, "reason", "dep", error))
-            return FALSE;
-    }
+    reason = hif_transaction_get_propagated_reason(transaction, goal, pkg);
+    if (!hif_db_set_string(priv->db, pkg, "reason", reason, error))
+        return FALSE;
 
     /* set the correct release */
     tmp = hif_context_get_release_ver(priv->context);
@@ -957,6 +1000,7 @@ _hif_state_get_step_multiple_pair(guint first, guint second)
  **/
 static gboolean
 hif_transaction_write_yumdb(HifTransaction *transaction,
+                 HyGoal goal,
                  HifState *state,
                  GError **error)
 {
@@ -1004,6 +1048,7 @@ hif_transaction_write_yumdb(HifTransaction *transaction,
         pkg = g_ptr_array_index(priv->install, i);
         state_loop = hif_state_get_child(state_local);
         ret = hif_transaction_write_yumdb_install_item(transaction,
+                                                       goal,
                                                        pkg,
                                                        state_loop,
                                                        error);
@@ -1134,6 +1179,10 @@ hif_transaction_reset(HifTransaction *transaction)
         g_ptr_array_unref(priv->remove_helper);
         priv->remove_helper = NULL;
     }
+    if (priv->erased_by_package_hash != NULL) {
+        g_hash_table_unref(priv->erased_by_package_hash);
+        priv->erased_by_package_hash = NULL;
+    }
 }
 
 /**
@@ -1168,6 +1217,7 @@ hif_transaction_commit(HifTransaction *transaction,
     guint i;
     guint j;
     HifState *state_local;
+    GPtrArray *all_obsoleted;
     GPtrArray *pkglist;
     HifPackage *pkg;
     HifPackage *pkg_tmp;
@@ -1319,6 +1369,30 @@ hif_transaction_commit(HifTransaction *transaction,
     if (!ret)
         goto out;
 
+    /* map updated packages to their previous versions */
+    priv->erased_by_package_hash = g_hash_table_new_full(g_str_hash, g_str_equal,
+                                                         g_free, (GDestroyNotify) g_object_unref);
+    all_obsoleted = hy_goal_list_obsoleted(goal, NULL);
+    for (i = 0; i < priv->install->len; i++) {
+        pkg = g_ptr_array_index(priv->install, i);
+        if (hif_package_get_action(pkg) != HIF_STATE_ACTION_UPDATE &&
+            hif_package_get_action(pkg) != HIF_STATE_ACTION_DOWNGRADE &&
+            hif_package_get_action(pkg) != HIF_STATE_ACTION_REINSTALL)
+            continue;
+
+        pkglist = hy_goal_list_obsoleted_by_package(goal, pkg);
+        for (j = 0; j < pkglist->len; j++) {
+            pkg_tmp = g_ptr_array_index(pkglist, i);
+            if (!hy_packagelist_has(all_obsoleted, pkg_tmp)) {
+                g_hash_table_insert(priv->erased_by_package_hash,
+                                    g_strdup(hif_package_get_package_id(pkg)),
+                                    g_object_ref(pkg_tmp));
+            }
+        }
+        g_ptr_array_unref(pkglist);
+    }
+    g_ptr_array_unref(all_obsoleted);
+
     /* generate ordering for the transaction */
     rpmtsOrder(priv->ts);
 
@@ -1400,6 +1474,7 @@ hif_transaction_commit(HifTransaction *transaction,
     /* write to the yumDB */
     state_local = hif_state_get_child(state);
     ret = hif_transaction_write_yumdb(transaction,
+                                      goal,
                                       state_local,
                                       error);
     if (!ret)

--- a/libhif/hif-transaction.c
+++ b/libhif/hif-transaction.c
@@ -1013,7 +1013,7 @@ hif_transaction_write_yumdb(HifTransaction *transaction,
     guint steps_auto;
 
     steps_auto = _hif_state_get_step_multiple_pair(priv->install->len,
-                                                   priv->remove->len);
+                                                   priv->remove->len + priv->remove_helper->len);
     ret = hif_state_set_steps(state,
                               error,
                               steps_auto,       /* install */
@@ -1046,10 +1046,19 @@ hif_transaction_write_yumdb(HifTransaction *transaction,
         return FALSE;
 
     /* remove all the old entries */
-    if (priv->remove->len > 0)
-        hif_state_set_number_steps(state_local, priv->remove->len);
+    if ((priv->remove->len + priv->remove_helper->len) > 0)
+        hif_state_set_number_steps(state_local, priv->remove->len + priv->remove_helper->len);
     for (i = 0; i < priv->remove->len; i++) {
         pkg = g_ptr_array_index(priv->remove, i);
+        if (!hif_transaction_ensure_repo(transaction, pkg, error))
+            return FALSE;
+        if (!hif_db_remove_all(priv->db, pkg, error))
+            return FALSE;
+        if (!hif_state_done(state_local, error))
+            return FALSE;
+    }
+    for (i = 0; i < priv->remove_helper->len; i++) {
+        pkg = g_ptr_array_index(priv->remove_helper, i);
         if (!hif_transaction_ensure_repo(transaction, pkg, error))
             return FALSE;
         if (!hif_db_remove_all(priv->db, pkg, error))

--- a/libhif/hif-transaction.c
+++ b/libhif/hif-transaction.c
@@ -1012,35 +1012,18 @@ hif_transaction_write_yumdb(HifTransaction *transaction,
     guint i;
     guint steps_auto;
 
-    steps_auto = _hif_state_get_step_multiple_pair(priv->remove->len,
-                                                   priv->install->len);
+    steps_auto = _hif_state_get_step_multiple_pair(priv->install->len,
+                                                   priv->remove->len);
     ret = hif_state_set_steps(state,
                               error,
-                              steps_auto,       /* remove */
-                              100 - steps_auto, /* install */
+                              steps_auto,       /* install */
+                              100 - steps_auto, /* remove */
                               -1);
     if (!ret)
         return FALSE;
 
-    /* remove all the old entries */
-    state_local = hif_state_get_child(state);
-    if (priv->remove->len > 0)
-        hif_state_set_number_steps(state_local, priv->remove->len);
-    for (i = 0; i < priv->remove->len; i++) {
-        pkg = g_ptr_array_index(priv->remove, i);
-        if (!hif_transaction_ensure_repo(transaction, pkg, error))
-            return FALSE;
-        if (!hif_db_remove_all(priv->db, pkg, error))
-            return FALSE;
-        if (!hif_state_done(state_local, error))
-            return FALSE;
-    }
-
-    /* this section done */
-    if (!hif_state_done(state, error))
-        return FALSE;
-
     /* add all the new entries */
+    state_local = hif_state_get_child(state);
     if (priv->install->len > 0)
         hif_state_set_number_steps(state_local,
                         priv->install->len);
@@ -1053,6 +1036,23 @@ hif_transaction_write_yumdb(HifTransaction *transaction,
                                                        state_loop,
                                                        error);
         if (!ret)
+            return FALSE;
+        if (!hif_state_done(state_local, error))
+            return FALSE;
+    }
+
+    /* this section done */
+    if (!hif_state_done(state, error))
+        return FALSE;
+
+    /* remove all the old entries */
+    if (priv->remove->len > 0)
+        hif_state_set_number_steps(state_local, priv->remove->len);
+    for (i = 0; i < priv->remove->len; i++) {
+        pkg = g_ptr_array_index(priv->remove, i);
+        if (!hif_transaction_ensure_repo(transaction, pkg, error))
+            return FALSE;
+        if (!hif_db_remove_all(priv->db, pkg, error))
             return FALSE;
         if (!hif_state_done(state_local, error))
             return FALSE;


### PR DESCRIPTION
Here's a few patches that fix a bunch of issues with yumdb handling in libhif. I worked on these to fix a Fedora 24 blocker bug, https://bugzilla.redhat.com/show_bug.cgi?id=1259865 and we ended up rushing these through the Fedora freeze to avoid slipping the Beta. The fixes we ended up with in Fedora were extensively tested by both me and Fedora QA and I pushed them directly to the 0_2_X branch.

The patches in this pull request however, are manually forward ported to master across the various API changes and whitespace changes and so on, and I don't have a lot of confidence in them as I don't know how to test master. PackageKit is still on the 0_2_X branch.

Sadly, there is no testsuite coverage for this whole area (transactions / package installation / removal / yumdb) so we can't rely on tests here either. Also, libhif tests are failing here both with and without this patch set.

I'd be happy to write tests for yumdb stuff if someone who understands libhif better comes up with a framework for testing actual package installation, which is currently missing. Once we have that, yumdb tests should be straightforward to add.