### PR TITLE
[merged] hif_context_install: revert back to all arches

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -1593,18 +1593,17 @@ hif_context_run(HifContext *context, GCancellable *cancellable, GError **error)
  * Since: 0.1.0
  **/
 gboolean
-hif_context_install(HifContext *context, const gchar *name, GError **error)
+hif_context_install (HifContext *context, const gchar *name, GError **error)
 {
-    HifContextPrivate *priv = GET_PRIVATE(context);
-    GPtrArray *pkglist;
+    HifContextPrivate *priv = GET_PRIVATE (context);
+    g_autoptr(GPtrArray) pkglist = NULL;
     HifPackage *pkg;
     HyQuery query;
     gboolean ret = TRUE;
-    guint i;
 
-    /* create sack and add repos */
+    /* create sack and add sources */
     if (priv->sack == NULL) {
-        hif_state_reset(priv->state);
+        hif_state_reset (priv->state);
         ret = hif_context_setup_sack(context, priv->state, error);
         if (!ret)
             return FALSE;
@@ -1634,7 +1633,6 @@ hif_context_install(HifContext *context, const gchar *name, GError **error)
     g_debug("adding %s-%s to goal", hif_package_get_name(pkg), hif_package_get_evr(pkg));
     hy_goal_install(priv->goal, pkg);
 
-    g_ptr_array_unref(pkglist);
     hy_query_free(query);
     return TRUE;
 }


### PR DESCRIPTION
This is mostly a revert of commit 2f68fea (#50) with two modifications:
  1. use hy_query_filter_latest() instead of hy_query_latest_by_arch()
  2. just pick the first pkg if multiple packages have the same version

The issue that #50 introduced is that multiple packages can be returned,
not necessarily of the same NEVR. Since we just picked whatever the
first package in the array was, we would sometimes be choosing older
packages.

Now, with hy_query_filter_latest(), we just always pick the latest NEVR,
regardless of the arch (so it should still cover cases where a pkg goes
from noarch to not noarch).

Resolves: #120