### PR TITLE
[merged] Add build option to enable urpmreorder solver flag (MgaBug:18315)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,6 +19,8 @@ ADD_DEFINITIONS(-DG_LOG_DOMAIN=\\"libhif\\")
 
 INCLUDE_DIRECTORIES (${CMAKE_SOURCE_DIR})
 
+OPTION (ENABLE_SOLV_URPMREORDER "Build with support for URPM-like solution reordering?" OFF)
+
 # hawkey dependencies
 find_package (PkgConfig REQUIRED)
 SET (CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
@@ -31,6 +33,10 @@ FIND_PROGRAM (VALGRIND_PROGRAM NAMES valgrind PATH /usr/bin /usr/local/bin)
 
 # TODO handle yumdb / dnfdb for libhif
 ADD_DEFINITIONS(-DBUILDOPT_USE_DNF_YUMDB=1)
+
+IF (ENABLE_SOLV_URPMREORDER)
+   ADD_DEFINITIONS(-DLIBSOLV_FLAG_URPMREORDER=1)
+ENDIF()
 
 INCLUDE_DIRECTORIES(${GLIB_INCLUDE_DIRS})
 

--- a/libhif.spec
+++ b/libhif.spec
@@ -1,4 +1,4 @@
-%global libsolv_version 0.6.20-1
+%global libsolv_version 0.6.21-1
 
 %bcond_with valgrind
 

--- a/libhif/hy-goal.c
+++ b/libhif/hy-goal.c
@@ -219,6 +219,11 @@ init_solver(HyGoal goal, HifGoalActions flags)
     /* support package splits via obsoletes */
     solver_set_flag(solv, SOLVER_FLAG_YUM_OBSOLETES, 1);
 
+#if defined(LIBSOLV_FLAG_URPMREORDER)
+    /* support urpm-like solution reordering */
+    solver_set_flag(solv, SOLVER_FLAG_URPM_REORDER, 1);
+#endif
+
     return solv;
 }
 


### PR DESCRIPTION
This optionally enables the urpm-style solution reordering required to ensure the proper subset of locale/kernel subpackages were being installed. This partly solves [MgaBug#18315](https://bugs.mageia.org/show_bug.cgi?id=18315).

This flag enables [functionality present in libsolv git master](https://github.com/openSUSE/libsolv/commit/565280da80a62dbd48bcd30043149be210e3b5c3), and I've already [backported it to libsolv-0.6.20](https://svnweb.mageia.org/packages/cauldron/libsolv/current/SOURCES/libsolv-0.6.20-Backport-SOLVER_FLAG_URPM_REORDER-solver-flag.patch?revision=1014972&view=markup) and [enabled it in the hawkey-0.6.3 package](https://svnweb.mageia.org/packages/cauldron/hawkey/current/SOURCES/hawkey-0.6.3-Enable-URPM-style-solution-reordering.patch?revision=1018177&view=markup) for Mageia.