### PR TITLE
[merged] hif-goal: make hif_goal_depsolve() take flags

### DIFF
--- a/libhif/hif-goal.c
+++ b/libhif/hif-goal.c
@@ -40,9 +40,16 @@
 
 /**
  * hif_goal_depsolve:
+ * @goal: a #HyGoal.
+ * @flags: some #HifGoalActions to enable.
+ * @error: a #GError or %NULL
+ *
+ * Returns: %TRUE if depsolve is successful.
+ *
+ * Since: 0.7.0
  */
 gboolean
-hif_goal_depsolve(HyGoal goal, GError **error)
+hif_goal_depsolve(HyGoal goal, HifGoalActions flags, GError **error)
 {
     gchar *tmp;
     gint cnt;
@@ -50,7 +57,7 @@ hif_goal_depsolve(HyGoal goal, GError **error)
     gint rc;
     g_autoptr(GString) string = NULL;
 
-    rc = hy_goal_run_flags(goal, HIF_ALLOW_UNINSTALL);
+    rc = hy_goal_run_flags(goal, flags);
     if (rc) {
         string = g_string_new("Could not depsolve transaction; ");
         cnt = hy_goal_count_problems(goal);

--- a/libhif/hif-goal.h
+++ b/libhif/hif-goal.h
@@ -28,7 +28,8 @@
 #include "hy-package.h"
 
 gboolean         hif_goal_depsolve                      (HyGoal          goal,
-                                                         GError         **error);
+                                                         HifGoalActions  flags,
+                                                         GError          **error);
 GPtrArray       *hif_goal_get_packages                  (HyGoal          goal,
                                                          ...);
 

--- a/libhif/hif-transaction.c
+++ b/libhif/hif-transaction.c
@@ -1069,7 +1069,7 @@ hif_transaction_depsolve(HifTransaction *transaction,
     g_autoptr(GPtrArray) packages = NULL;
 
     /* depsolve */
-    if (!hif_goal_depsolve(goal, error))
+    if (!hif_goal_depsolve(goal, HIF_ALLOW_UNINSTALL, error))
         return FALSE;
 
     /* find a list of all the packages we have to download */


### PR DESCRIPTION
This allows clients to have more fine-grained control over the behaviour
of the depsolve, e.g. if they don't want `HIF_ALLOW_UNINSTALL` enabled.

---

I found a need for this while working on package layering in rpm-ostree. There, uninstalling to meet our goal is not an option. (Though I'm not sure why this is the default in the first place, shouldn't it be a flag somewhere?)