### PR TITLE
sack: don't raise error when non-existing arch is used

### DIFF
--- a/libhif/hif-sack.c
+++ b/libhif/hif-sack.c
@@ -792,6 +792,9 @@ hif_sack_set_arch (HifSack *sack, const gchar *value, GError **error)
     g_debug("Architecture is: %s", arch);
     pool_setarch(pool, arch);
 
+    /* Since one of commits after 0.6.20 libsolv allowes custom arches
+     * which means it will be 'newcoolarch' ad 'noarch' always. */
+#if LIBSOLV_VERSION <= 620
     /* noarch never fails */
     if (!strcmp(arch, "noarch"))
         return TRUE;
@@ -810,6 +813,7 @@ hif_sack_set_arch (HifSack *sack, const gchar *value, GError **error)
                      "autodetection failed (noarch invalid)");
         return FALSE;
     }
+#endif
     priv->have_set_arch = TRUE;
     return TRUE;
 }

--- a/python/hawkey/tests/tests/test_sack.py
+++ b/python/hawkey/tests/tests/test_sack.py
@@ -56,7 +56,6 @@ class BasicTest(unittest.TestCase):
         hawkey.Sack(arch="noarch")
         hawkey.Sack(arch="x86_64")
         self.assertRaises(hawkey.ArchException, hawkey.Sack, arch="")
-        self.assertRaises(hawkey.ValueException, hawkey.Sack, arch="play")
 
     def test_deepcopy(self):
         sack = hawkey.Sack()


### PR DESCRIPTION
Since libsolv's commit aea953a42d99399938eb6c98a220310aa438c376 it allows
to use any arches which are not in white list.

Reference: https://github.com/rpm-software-management/libhif/issues/118
Signed-off-by: Igor Gnatenko <ignatenko@redhat.com>