### PR TITLE
[merged] transaction: Check for available disk space before downloading packages

### DIFF
--- a/libhif/hif-transaction.c
+++ b/libhif/hif-transaction.c
@@ -1017,6 +1017,80 @@ hif_transaction_write_yumdb(HifTransaction *transaction,
     return hif_state_done(state, error);
 }
 
+static guint64
+hif_transaction_get_download_size(HifTransaction *transaction)
+{
+    HifTransactionPrivate *priv = GET_PRIVATE(transaction);
+    guint i;
+    guint64 download_size = 0;
+
+    for (i = 0; i < priv->pkgs_to_download->len; i++) {
+        HifPackage *pkg = g_ptr_array_index(priv->pkgs_to_download, i);
+
+        download_size += hif_package_get_downloadsize(pkg);
+    }
+
+    return download_size;
+}
+
+static gboolean
+hif_transaction_check_free_space(HifTransaction *transaction,
+                                 GError **error)
+{
+    HifTransactionPrivate *priv = GET_PRIVATE(transaction);
+    const gchar *cachedir;
+    guint64 download_size;
+    guint64 free_space;
+    g_autoptr(GFile) file = NULL;
+    g_autoptr(GFileInfo) filesystem_info = NULL;
+
+    download_size = hif_transaction_get_download_size(transaction);
+
+    cachedir = hif_context_get_cache_dir(priv->context);
+    if (cachedir == NULL) {
+        g_set_error_literal(error,
+                            HIF_ERROR,
+                            HIF_ERROR_FAILED_CONFIG_PARSING,
+                            "Failed to get value for CacheDir");
+        return FALSE;
+    }
+
+    file = g_file_new_for_path(cachedir);
+    filesystem_info = g_file_query_filesystem_info(file, G_FILE_ATTRIBUTE_FILESYSTEM_FREE, NULL, error);
+    if (filesystem_info == NULL) {
+        g_prefix_error(error, "Failed to get filesystem free size for %s: ", cachedir);
+        return FALSE;
+    }
+
+    if (!g_file_info_has_attribute(filesystem_info, G_FILE_ATTRIBUTE_FILESYSTEM_FREE)) {
+        g_set_error(error,
+                    HIF_ERROR,
+                    HIF_ERROR_FAILED,
+                    "Failed to get filesystem free size for %s",
+                    cachedir);
+        return FALSE;
+    }
+
+    free_space = g_file_info_get_attribute_uint64(filesystem_info, G_FILE_ATTRIBUTE_FILESYSTEM_FREE);
+    if (free_space < download_size) {
+        g_autofree gchar *formatted_download_size = NULL;
+        g_autofree gchar *formatted_free_size = NULL;
+
+        formatted_download_size = g_format_size(download_size);
+        formatted_free_size = g_format_size(free_space);
+        g_set_error(error,
+                    HIF_ERROR,
+                    HIF_ERROR_NO_SPACE,
+                    "Not enough free space in %s: needed %s, available %s",
+                    cachedir,
+                    formatted_download_size,
+                    formatted_free_size);
+        return FALSE;
+    }
+
+    return TRUE;
+}
+
 /**
  * hif_transaction_download:
  * @transaction: a #HifTransaction instance.
@@ -1035,6 +1109,10 @@ hif_transaction_download(HifTransaction *transaction,
                          GError **error)
 {
     HifTransactionPrivate *priv = GET_PRIVATE(transaction);
+
+    /* check that we have enough free space */
+    if (!hif_transaction_check_free_space(transaction, error))
+        return FALSE;
 
     /* just download the list */
     return hif_package_array_download(priv->pkgs_to_download,

--- a/libhif/hif-types.h
+++ b/libhif/hif-types.h
@@ -61,6 +61,7 @@ typedef struct _HifReldepList           HifReldepList;
  * @HIF_ERROR_NO_SOLUTION:                      No solution was possible
  * @HIF_ERROR_BAD_QUERY:                        The query was in some way bad
  * @HIF_ERROR_NO_CAPABILITY:                    This feature was not available
+ * @HIF_ERROR_NO_SPACE:                         Out of disk space
  *
  * The error code.
  **/
@@ -82,6 +83,7 @@ typedef enum {
         HIF_ERROR_REPO_NOT_FOUND                = 19,   /* Since: 0.1.0 */
         HIF_ERROR_FAILED_CONFIG_PARSING         = 24,   /* Since: 0.1.0 */
         HIF_ERROR_PACKAGE_NOT_FOUND             = 8,    /* Since: 0.1.0 */
+        HIF_ERROR_NO_SPACE                      = 46,   /* Since: 0.2.3 */
         HIF_ERROR_INVALID_ARCHITECTURE,                 /* Since: 0.7.0 */
         HIF_ERROR_BAD_SELECTOR,                         /* Since: 0.7.0 */
         HIF_ERROR_NO_SOLUTION,                          /* Since: 0.7.0 */


### PR DESCRIPTION
Fixes: https://bugzilla.redhat.com/show_bug.cgi?id=1336400

A bit of a confusion with hif error numbering here; the enum used to match up numerically with a PK enum, but now libhif master has a few new items in the error enum that don't have the matching numbers.

I've assigned:
HIF_ERROR_NO_SPACE                      = 46,   /* Since: 0.2.3 */

to it to match with what we are doing on the 0_2_X branch and to match up with the PK error enum, but perhaps PK should stop doing the enum conversion like that.