### PR TITLE
transaction: Add a flag to run transactions in test mode

### DIFF
--- a/libhif/hif-transaction.h
+++ b/libhif/hif-transaction.h
@@ -83,7 +83,9 @@ typedef enum {
 	HIF_TRANSACTION_FLAG_ALLOW_REINSTALL	= 1 << 1,
 	HIF_TRANSACTION_FLAG_ALLOW_DOWNGRADE	= 1 << 2,
 	HIF_TRANSACTION_FLAG_NODOCS		= 1 << 3,
-	HIF_TRANSACTION_FLAG_TEST		= 1 << 4
+	HIF_TRANSACTION_FLAG_TEST		= 1 << 4,
+	/*< private >*/
+	HIF_TRANSACTION_FLAG_LAST
 } HifTransactionFlag;
 
 GType		 hif_transaction_get_type		(void);

--- a/libhif/hif-transaction.h
+++ b/libhif/hif-transaction.h
@@ -73,6 +73,7 @@ struct _HifTransactionClass
  * @HIF_TRANSACTION_FLAG_ALLOW_REINSTALL:	Allow package reinstallation
  * @HIF_TRANSACTION_FLAG_ALLOW_DOWNGRADE:	Allow package downrades
  * @HIF_TRANSACTION_FLAG_NODOCS:	        Don't install documentation
+ * @HIF_TRANSACTION_FLAG_TEST:		        Only do a transaction test
  *
  * The transaction flags.
  **/
@@ -81,7 +82,8 @@ typedef enum {
 	HIF_TRANSACTION_FLAG_ONLY_TRUSTED		= 1 << 0,
 	HIF_TRANSACTION_FLAG_ALLOW_REINSTALL	= 1 << 1,
 	HIF_TRANSACTION_FLAG_ALLOW_DOWNGRADE	= 1 << 2,
-	HIF_TRANSACTION_FLAG_NODOCS		= 1 << 3
+	HIF_TRANSACTION_FLAG_NODOCS		= 1 << 3,
+	HIF_TRANSACTION_FLAG_TEST		= 1 << 4
 } HifTransactionFlag;
 
 GType		 hif_transaction_get_type		(void);


### PR DESCRIPTION
This makes it possible for PackageKit to do a transaction test before
rebooting into an offline update.