### PR TITLE
sack: Fix a step counting traceback with metadata only sources

### DIFF
--- a/libhif/hif-sack.c
+++ b/libhif/hif-sack.c
@@ -180,8 +180,16 @@ hif_sack_add_sources (HySack sack,
 	/* count the enabled sources */
 	for (i = 0; i < sources->len; i++) {
 		src = g_ptr_array_index (sources, i);
-		if (hif_source_get_enabled (src) != HIF_SOURCE_ENABLED_NONE)
-			cnt++;
+		if (hif_source_get_enabled (src) == HIF_SOURCE_ENABLED_NONE)
+			continue;
+
+		/* only allow metadata-only sources if FLAG_UNAVAILABLE is set */
+		if (hif_source_get_enabled (src) == HIF_SOURCE_ENABLED_METADATA) {
+			if ((flags & HIF_SACK_ADD_FLAG_UNAVAILABLE) == 0)
+				continue;
+		}
+
+		cnt++;
 	}
 
 	/* add each repo */


### PR DESCRIPTION
Make the step counting logic exactly match the loop down below, so that
we don't get a traceback from HifState.

Fixes PK warning:
    child is at 9/10 steps and parent done [pk-backend-hif.c:545]
    3) pk-backend-hif.c:2875 (0/4)
    2) pk-backend-hif.c:696 (1/2)
    1) pk-backend-hif.c:521 (1/2)
    0) hif-sack.c:188 (9/10)

I'll port this to master too if it looks good.