### PR TITLE
[merged] sack: Fix a step counting traceback with metadata only sources

### DIFF
--- a/libhif/hif-sack.c
+++ b/libhif/hif-sack.c
@@ -1781,8 +1781,16 @@ hif_sack_add_repos(HifSack *sack,
     /* count the enabled repos */
     for (i = 0; i < repos->len; i++) {
         repo = g_ptr_array_index(repos, i);
-        if (hif_repo_get_enabled(repo) != HIF_REPO_ENABLED_NONE)
-            cnt++;
+        if (hif_repo_get_enabled(repo) == HIF_REPO_ENABLED_NONE)
+            continue;
+
+        /* only allow metadata-only repos if FLAG_UNAVAILABLE is set */
+        if (hif_repo_get_enabled(repo) == HIF_REPO_ENABLED_METADATA) {
+            if ((flags & HIF_SACK_ADD_FLAG_UNAVAILABLE) == 0)
+                continue;
+        }
+
+        cnt++;
     }
 
     /* add each repo */


### PR DESCRIPTION
Make the step counting logic exactly match the loop down below, so that
we don't get a traceback from HifState.

Fixes PK warning:
    child is at 9/10 steps and parent done [pk-backend-hif.c:545]
    3) pk-backend-hif.c:2875 (0/4)
    2) pk-backend-hif.c:696 (1/2)
    1) pk-backend-hif.c:521 (1/2)
    0) hif-sack.c:188 (9/10)

This pull request is https://github.com/rpm-software-management/libhif/pull/132 ported from 0_2_X to master.