### PR TITLE
[merged] transaction: Add a flag to run transactions in test mode

### DIFF
--- a/libhif/hif-transaction.c
+++ b/libhif/hif-transaction.c
@@ -1184,15 +1184,25 @@ hif_transaction_commit(HifTransaction *transaction,
         goto out;
 
     /* set state */
-    ret = hif_state_set_steps(state,
-                              error,
-                              2, /* install */
-                              2, /* remove */
-                              10, /* test-commit */
-                              83, /* commit */
-                              1, /* write yumDB */
-                              2, /* delete files */
-                              -1);
+    if (priv->flags & HIF_TRANSACTION_FLAG_TEST) {
+        ret = hif_state_set_steps(state,
+                                  error,
+                                  2, /* install */
+                                  2, /* remove */
+                                  10, /* test-commit */
+                                  86, /* commit */
+                                  -1);
+    } else {
+        ret = hif_state_set_steps(state,
+                                  error,
+                                  2, /* install */
+                                  2, /* remove */
+                                  10, /* test-commit */
+                                  83, /* commit */
+                                  1, /* write yumDB */
+                                  2, /* delete files */
+                                  -1);
+    }
     if (!ret)
         goto out;
 
@@ -1358,6 +1368,35 @@ hif_transaction_commit(HifTransaction *transaction,
 
     if (priv->flags & HIF_TRANSACTION_FLAG_NODOCS)
         rpmts_flags |= RPMTRANS_FLAG_NODOCS;
+
+    if (priv->flags & HIF_TRANSACTION_FLAG_TEST) {
+        /* run the transaction in test mode */
+        rpmts_flags |= RPMTRANS_FLAG_TEST;
+
+        priv->state = hif_state_get_child(state);
+        priv->step = HIF_TRANSACTION_STEP_IGNORE;
+        rpmtsSetFlags(priv->ts, rpmts_flags);
+        g_debug("Running transaction in test mode");
+        hif_state_set_allow_cancel(state, FALSE);
+        rc = rpmtsRun(priv->ts, NULL, problems_filter);
+        if (rc < 0) {
+            ret = FALSE;
+            g_set_error(error,
+                        HIF_ERROR,
+                        HIF_ERROR_INTERNAL_ERROR,
+                        "Error %i running transaction test", rc);
+            goto out;
+        }
+        if (rc > 0) {
+            ret = hif_rpmts_look_for_problems(priv->ts, error);
+            if (!ret)
+                goto out;
+        }
+
+        /* transaction test done; return */
+        ret = hif_state_done(state, error);
+        goto out;
+    }
 
     /* run the transaction */
     priv->state = hif_state_get_child(state);

--- a/libhif/hif-transaction.h
+++ b/libhif/hif-transaction.h
@@ -68,7 +68,9 @@ typedef enum {
         HIF_TRANSACTION_FLAG_ALLOW_REINSTALL    = 1 << 1,
         HIF_TRANSACTION_FLAG_ALLOW_DOWNGRADE    = 1 << 2,
         HIF_TRANSACTION_FLAG_NODOCS             = 1 << 3,
-        HIF_TRANSACTION_FLAG_TEST               = 1 << 4
+        HIF_TRANSACTION_FLAG_TEST               = 1 << 4,
+        /*< private >*/
+        HIF_TRANSACTION_FLAG_LAST
 } HifTransactionFlag;
 
 HifTransaction  *hif_transaction_new                    (HifContext     *context);

--- a/libhif/hif-transaction.h
+++ b/libhif/hif-transaction.h
@@ -58,6 +58,7 @@ struct _HifTransactionClass
  * @HIF_TRANSACTION_FLAG_ALLOW_REINSTALL:       Allow package reinstallation
  * @HIF_TRANSACTION_FLAG_ALLOW_DOWNGRADE:       Allow package downrades
  * @HIF_TRANSACTION_FLAG_NODOCS:                Don't install documentation
+ * @HIF_TRANSACTION_FLAG_TEST:                  Only do a transaction test
  *
  * The transaction flags.
  **/
@@ -66,7 +67,8 @@ typedef enum {
         HIF_TRANSACTION_FLAG_ONLY_TRUSTED       = 1 << 0,
         HIF_TRANSACTION_FLAG_ALLOW_REINSTALL    = 1 << 1,
         HIF_TRANSACTION_FLAG_ALLOW_DOWNGRADE    = 1 << 2,
-        HIF_TRANSACTION_FLAG_NODOCS             = 1 << 3
+        HIF_TRANSACTION_FLAG_NODOCS             = 1 << 3,
+        HIF_TRANSACTION_FLAG_TEST               = 1 << 4
 } HifTransactionFlag;
 
 HifTransaction  *hif_transaction_new                    (HifContext     *context);


### PR DESCRIPTION
This makes it possible for PackageKit to do a transaction test before
rebooting into an offline update.

This pull request is https://github.com/rpm-software-management/libhif/pull/130 ported from 0_2_X to master.