### PR TITLE
[merged] properly support local install

### DIFF
--- a/cmake/modules/FindPythonInstDir.cmake
+++ b/cmake/modules/FindPythonInstDir.cmake
@@ -1,1 +1,6 @@
-EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "from sys import stdout; from distutils import sysconfig; stdout.write(sysconfig.get_python_lib(True))" OUTPUT_VARIABLE PYTHON_INSTALL_DIR)
+EXECUTE_PROCESS(COMMAND ${PYTHON_EXECUTABLE} -c "
+from sys import stdout
+from distutils import sysconfig
+path=sysconfig.get_python_lib(True, prefix='${CMAKE_INSTALL_PREFIX}')
+stdout.write(path)"
+OUTPUT_VARIABLE PYTHON_INSTALL_DIR)


### PR DESCRIPTION
I couldn't do an install in a local dir because CMake wanted to put the
hawkey python files in the system directories. The patch below fixed it
for me. Though I'm not a CMake expert, so there might be a more
canonical way of doing this.