### PR TITLE
[merged] libhif.pc.in: point Cflags to the includedir only

### DIFF
--- a/libhif/libhif.pc.in
+++ b/libhif/libhif.pc.in
@@ -7,4 +7,4 @@ Description: Simple package manager interface and librepo
 Version: @HIF_VERSION@
 Requires: glib-2.0, gobject-2.0, librepo, rpm
 Libs: -L${libdir} -lhif
-Cflags: -I${includedir}/libhif
+Cflags: -I${includedir}


### PR DESCRIPTION
We would previously set `Cflags` to include the libhif directory itself.
However, this causes problems for library users since libhif headers
themselves use include directives with the libhif prefix.

Let's change the `Cflags` to point to just `${includedir}` and require users
to always prefix their includes.

See https://github.com/rpm-software-management/libhif/pull/136#issuecomment-224768068 for more background information.