### PR TITLE
[merged] context: Add hif_context_set_user_agent()

### DIFF
--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -147,6 +147,7 @@ hif_context_finalize(GObject *object)
     g_free(priv->os_info);
     g_free(priv->arch_info);
     g_free(priv->http_proxy);
+    g_free(priv->user_agent);
     g_strfreev(priv->native_arches);
     g_object_unref(priv->lock);
     g_object_unref(priv->state);
@@ -584,8 +585,8 @@ hif_context_get_state(HifContext *context)
  *
  * Returns: (transfer none): the user agent
  **/
-const char *
-hif_context_get_user_agent (HifContext     *context)
+const gchar *
+hif_context_get_user_agent (HifContext *context)
 {
     HifContextPrivate *priv = GET_PRIVATE(context);
     return priv->user_agent;

--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -93,6 +93,7 @@ typedef struct
     gchar            *rpm_verbosity;
     gchar            **native_arches;
     gchar            *http_proxy;
+    gchar            *user_agent;
     gboolean         cache_age;
     gboolean         check_disk_space;
     gboolean         check_transaction;
@@ -181,6 +182,7 @@ hif_context_init(HifContext *context)
     priv->cache_age = 60 * 60 * 24 * 7; /* 1 week */
     priv->override_macros = g_hash_table_new_full(g_str_hash, g_str_equal,
                                                   g_free, g_free);
+    priv->user_agent = g_strdup("libhif/" PACKAGE_VERSION);
 
     /* Initialize some state that used to happen in
      * hif_context_setup(), because callers like rpm-ostree want
@@ -574,6 +576,19 @@ hif_context_get_state(HifContext *context)
 {
     HifContextPrivate *priv = GET_PRIVATE(context);
     return priv->state;
+}
+
+/**
+ * hif_context_get_user_agent:
+ * @context: a #HifContext instance.
+ *
+ * Returns: (transfer none): the user agent
+ **/
+const char *
+hif_context_get_user_agent (HifContext     *context)
+{
+    HifContextPrivate *priv = GET_PRIVATE(context);
+    return priv->user_agent;
 }
 
 /**
@@ -1036,6 +1051,20 @@ hif_context_set_os_release(HifContext *context, GError **error)
         return FALSE;
     hif_context_set_release_ver(context, version);
     return TRUE;
+}
+
+/**
+ * hif_context_set_user_agent:
+ * @context: Context
+ * @user_agent: User-Agent string for HTTP requests
+ **/
+void
+hif_context_set_user_agent (HifContext     *context,
+                            const gchar    *user_agent)
+{
+    HifContextPrivate *priv = GET_PRIVATE(context);
+    g_free (priv->user_agent);
+    priv->user_agent = g_strdup (user_agent);
 }
 
 /**

--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -1060,7 +1060,7 @@ hif_context_set_os_release(HifContext *context, GError **error)
  * @user_agent: User-Agent string for HTTP requests
  **/
 void
-hif_context_set_user_agent (HifContext *context,
+hif_context_set_user_agent (HifContext  *context,
                             const gchar *user_agent)
 {
     HifContextPrivate *priv = GET_PRIVATE(context);

--- a/libhif/hif-context.c
+++ b/libhif/hif-context.c
@@ -1060,8 +1060,8 @@ hif_context_set_os_release(HifContext *context, GError **error)
  * @user_agent: User-Agent string for HTTP requests
  **/
 void
-hif_context_set_user_agent (HifContext     *context,
-                            const gchar    *user_agent)
+hif_context_set_user_agent (HifContext *context,
+                            const gchar *user_agent)
 {
     HifContextPrivate *priv = GET_PRIVATE(context);
     g_free (priv->user_agent);

--- a/libhif/hif-context.h
+++ b/libhif/hif-context.h
@@ -99,6 +99,7 @@ HifSack         *hif_context_get_sack                   (HifContext     *context
 HyGoal           hif_context_get_goal                   (HifContext     *context);
 #endif
 HifState*        hif_context_get_state                  (HifContext     *context);
+const char *     hif_context_get_user_agent             (HifContext     *context);
 
 /* setters */
 void             hif_context_set_repo_dir               (HifContext     *context,
@@ -139,6 +140,8 @@ void             hif_context_set_rpm_macro              (HifContext     *context
                                                          const gchar    *value);
 void             hif_context_set_http_proxy             (HifContext     *context,
                                                          const gchar    *proxyurl);
+void             hif_context_set_user_agent             (HifContext     *context,
+                                                         const gchar    *user_agent);
 
 /* object methods */
 gboolean         hif_context_setup                      (HifContext     *context,

--- a/libhif/hif-repo.c
+++ b/libhif/hif-repo.c
@@ -868,8 +868,7 @@ hif_repo_setup(HifRepo *repo, GError **error)
                             "releasever not set");
         return FALSE;
     }
-    user_agent = g_strdup_printf("PackageKit-hawkey/%s", PACKAGE_VERSION);
-    if (!lr_handle_setopt(priv->repo_handle, error, LRO_USERAGENT, user_agent))
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_USERAGENT, hif_context_get_user_agent(priv->context)))
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_REPOTYPE, LR_YUMREPO))
         return FALSE;


### PR DESCRIPTION
First, we aren't PackageKit/hawkey anymore.  Second, allow configuring
this so programs like rpm-ostree can override it.