### PR TITLE
[merged] hif_repo_setup: add support for ssl configuration

### DIFF
--- a/libhif/hif-repo.c
+++ b/libhif/hif-repo.c
@@ -764,7 +764,7 @@ hif_repo_set_keyfile_data(HifRepo *repo, GError **error)
     }
 
     /* set location if currently unset */
-    if (!lr_handle_setopt(priv->repo_handle, error, LRO_LOCAL, FALSE))
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_LOCAL, 0L))
         return FALSE;
     if (priv->location == NULL) {
         g_autofree gchar *tmp = NULL;
@@ -797,7 +797,9 @@ hif_repo_set_keyfile_data(HifRepo *repo, GError **error)
                             "gpgkey not set, yet repo_gpgcheck=1");
         return FALSE;
     }
-    if (!lr_handle_setopt(priv->repo_handle, error, LRO_GPGCHECK, priv->gpgcheck_md))
+
+    /* XXX: setopt() expects a long, so we need a long on the stack */
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_GPGCHECK, (long)priv->gpgcheck_md))
         return FALSE;
 
     exclude_string = g_key_file_get_string(priv->keyfile, priv->id, "exclude", NULL);
@@ -876,7 +878,7 @@ hif_repo_setup(HifRepo *repo, GError **error)
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_REPOTYPE, LR_YUMREPO))
         return FALSE;
-    if (!lr_handle_setopt(priv->repo_handle, error, LRO_INTERRUPTIBLE, FALSE))
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_INTERRUPTIBLE, 0L))
         return FALSE;
     priv->urlvars = lr_urlvars_set(priv->urlvars, "releasever", release);
     priv->urlvars = lr_urlvars_set(priv->urlvars, "basearch", basearch);
@@ -1034,9 +1036,9 @@ hif_repo_check_internal(HifRepo *repo,
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_DESTDIR, priv->location))
         return FALSE;
-    if (!lr_handle_setopt(priv->repo_handle, error, LRO_LOCAL, TRUE))
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_LOCAL, 1L))
         return FALSE;
-    if (!lr_handle_setopt(priv->repo_handle, error, LRO_CHECKSUM, TRUE))
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_CHECKSUM, 1L))
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_YUMDLIST, download_list))
         return FALSE;
@@ -1404,7 +1406,7 @@ hif_repo_update(HifRepo *repo,
 
     g_debug("Attempting to update %s", priv->id);
     ret = lr_handle_setopt(priv->repo_handle, error,
-                           LRO_LOCAL, FALSE);
+                           LRO_LOCAL, 0L);
     if (!ret)
         goto out;
     ret = lr_handle_setopt(priv->repo_handle, error,

--- a/libhif/hif-repo.c
+++ b/libhif/hif-repo.c
@@ -890,9 +890,10 @@ hif_repo_setup(HifRepo *repo, GError **error)
     if (g_key_file_has_key(priv->keyfile, priv->id, "sslverify", NULL))
         sslverify = g_key_file_get_boolean(priv->keyfile, priv->id, "sslverify", NULL);
 
-    if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYPEER, sslverify))
+    /* XXX: setopt() expects a long, so we need a long on the stack */
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYPEER, (long)sslverify))
         return FALSE;
-    if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYHOST, sslverify))
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYHOST, (long)sslverify))
         return FALSE;
 
     sslcacert = g_key_file_get_string(priv->keyfile, priv->id, "sslcacert", NULL);

--- a/libhif/hif-repo.c
+++ b/libhif/hif-repo.c
@@ -850,6 +850,7 @@ hif_repo_setup(HifRepo *repo, GError **error)
     g_autofree gchar *sslcacert = NULL;
     g_autofree gchar *sslclientcert = NULL;
     g_autofree gchar *sslclientkey = NULL;
+    gboolean sslverify = TRUE;
 
     basearch = g_key_file_get_string(priv->keyfile, "general", "arch", NULL);
     if (basearch == NULL)
@@ -886,13 +887,14 @@ hif_repo_setup(HifRepo *repo, GError **error)
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_GNUPGHOMEDIR, priv->keyring))
         return FALSE;
 
-    if (g_key_file_has_key(priv->keyfile, priv->id, "sslverify", NULL)) {
-        if (g_key_file_get_boolean(priv->keyfile, priv->id, "sslverify", NULL)) {
-            if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYPEER, TRUE))
-                return FALSE;
-            if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYHOST, TRUE))
-                return FALSE;
-        }
+    if (g_key_file_has_key(priv->keyfile, priv->id, "sslverify", NULL))
+        sslverify = g_key_file_get_boolean(priv->keyfile, priv->id, "sslverify", NULL);
+
+    if (sslverify) {
+        if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYPEER, TRUE))
+            return FALSE;
+        if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYHOST, TRUE))
+            return FALSE;
     }
 
     sslcacert = g_key_file_get_string(priv->keyfile, priv->id, "sslcacert", NULL);

--- a/libhif/hif-repo.c
+++ b/libhif/hif-repo.c
@@ -890,12 +890,10 @@ hif_repo_setup(HifRepo *repo, GError **error)
     if (g_key_file_has_key(priv->keyfile, priv->id, "sslverify", NULL))
         sslverify = g_key_file_get_boolean(priv->keyfile, priv->id, "sslverify", NULL);
 
-    if (sslverify) {
-        if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYPEER, TRUE))
-            return FALSE;
-        if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYHOST, TRUE))
-            return FALSE;
-    }
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYPEER, sslverify))
+        return FALSE;
+    if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYHOST, sslverify))
+        return FALSE;
 
     sslcacert = g_key_file_get_string(priv->keyfile, priv->id, "sslcacert", NULL);
     if (sslcacert != NULL) {

--- a/libhif/hif-repo.c
+++ b/libhif/hif-repo.c
@@ -847,6 +847,9 @@ hif_repo_setup(HifRepo *repo, GError **error)
     g_autofree gchar *release = NULL;
     g_autofree gchar *testdatadir = NULL;
     g_autofree gchar *user_agent = NULL;
+    g_autofree gchar *sslcacert = NULL;
+    g_autofree gchar *sslclientcert = NULL;
+    g_autofree gchar *sslclientkey = NULL;
 
     basearch = g_key_file_get_string(priv->keyfile, "general", "arch", NULL);
     if (basearch == NULL)
@@ -882,6 +885,34 @@ hif_repo_setup(HifRepo *repo, GError **error)
         return FALSE;
     if (!lr_handle_setopt(priv->repo_handle, error, LRO_GNUPGHOMEDIR, priv->keyring))
         return FALSE;
+
+    if (g_key_file_has_key(priv->keyfile, priv->id, "sslverify", NULL)) {
+        if (g_key_file_get_boolean(priv->keyfile, priv->id, "sslverify", NULL)) {
+            if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYPEER, TRUE))
+                return FALSE;
+            if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLVERIFYHOST, TRUE))
+                return FALSE;
+        }
+    }
+
+    sslcacert = g_key_file_get_string(priv->keyfile, priv->id, "sslcacert", NULL);
+    if (sslcacert != NULL) {
+        if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLCACERT, sslcacert))
+            return FALSE;
+    }
+
+    sslclientcert = g_key_file_get_string(priv->keyfile, priv->id, "sslclientcert", NULL);
+    if (sslclientcert != NULL) {
+        if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLCLIENTCERT, sslclientcert))
+            return FALSE;
+    }
+
+    sslclientkey = g_key_file_get_string(priv->keyfile, priv->id, "sslclientkey", NULL);
+    if (sslclientkey != NULL) {
+        if (!lr_handle_setopt(priv->repo_handle, error, LRO_SSLCLIENTKEY, sslclientkey))
+            return FALSE;
+    }
+
     return hif_repo_set_keyfile_data(repo, error);
 }
 


### PR DESCRIPTION
Pick up ssl-related configs from the repo file and pass them on to
librepo. This is analogous to the dnf patch:

https://github.com/rpm-software-management/dnf/pull/273

This does bring up the requirement of librepo to 1.7.15, which was
released on Apr 14, 2015.