### PR TITLE
source: Request multiple packages at once from librepo

### DIFF
--- a/libhif/hif-package.c
+++ b/libhif/hif-package.c
@@ -782,3 +782,28 @@ hif_package_array_download (GPtrArray *packages,
 	}
 	return TRUE;
 }
+
+/**
+ * hif_package_array_get_download_size:
+ * @packages: an array of packages.
+ *
+ * Gets the download size for an array of packages.
+ *
+ * Returns: the download size
+ *
+ * Since: 0.2.3
+ */
+guint64
+hif_package_array_get_download_size (GPtrArray *packages)
+{
+	guint i;
+	guint64 download_size = 0;
+
+	for (i = 0; i < packages->len; i++) {
+		HyPackage pkg = g_ptr_array_index (packages, i);
+
+		download_size += hy_package_get_downloadsize (pkg);
+	}
+
+	return download_size;
+}

--- a/libhif/hif-package.h
+++ b/libhif/hif-package.h
@@ -100,5 +100,6 @@ gboolean	 hif_package_array_download		(GPtrArray	*packages,
 							 const gchar	*directory,
 							 HifState	*state,
 							 GError		**error);
+guint64		 hif_package_array_get_download_size	(GPtrArray	*packages);
 
 #endif /* __HIF_PACKAGE_H */

--- a/libhif/hif-source.c
+++ b/libhif/hif-source.c
@@ -1634,19 +1634,72 @@ hif_source_copy_package (HyPackage pkg,
 			    hif_source_copy_progress_cb, state, error);
 }
 
-struct DownloadState {
-	HifState *state;
+typedef struct
+{
 	gchar *last_mirror_url;
 	gchar *last_mirror_failure_message;
-};
+	guint64 downloaded;
+	guint64 download_size;
+} GlobalDownloadData;
+
+typedef struct
+{
+	HyPackage pkg;
+	HifState *state;
+	guint64 downloaded;
+	GlobalDownloadData *global_download_data;
+} PackageDownloadData;
 
 static int
 package_download_update_state_cb (void *user_data,
 				  gdouble total_to_download,
 				  gdouble now_downloaded)
 {
-	struct DownloadState *dlstate = user_data;
-	return hif_source_update_state_cb (dlstate->state, total_to_download, now_downloaded);
+	PackageDownloadData *data = user_data;
+	GlobalDownloadData *global_data = data->global_download_data;
+	gboolean ret;
+	gdouble percentage;
+	guint64 previously_downloaded;
+
+	/* abort */
+	if (!hif_state_check (data->state, NULL))
+		return -1;
+
+	/* nothing sensible */
+	if (total_to_download < 0 || now_downloaded < 0)
+		return 0;
+
+	hif_state_action_start (data->state,
+	                        HIF_STATE_ACTION_DOWNLOAD_PACKAGES,
+	                        hif_package_get_id (data->pkg));
+
+	previously_downloaded = data->downloaded;
+	data->downloaded = now_downloaded;
+
+	global_data->downloaded += (now_downloaded - previously_downloaded);
+
+	/* set percentage */
+	percentage = 100.0f * global_data->downloaded / global_data->download_size;
+	ret = hif_state_set_percentage (data->state, percentage);
+	if (ret) {
+		g_debug ("update state %d/%d",
+			 (int)global_data->downloaded,
+			 (int)global_data->download_size);
+	}
+
+	return 0;
+}
+
+static int
+package_download_end_cb (void *user_data,
+                         LrTransferStatus status,
+                         const char *msg)
+{
+	PackageDownloadData *data = user_data;
+
+	g_slice_free (PackageDownloadData, data);
+
+	return LR_CB_OK;
 }
 
 static int
@@ -1654,14 +1707,15 @@ mirrorlist_failure_cb (void *user_data,
 		       const char *message,
 		       const char *url)
 {
-	struct DownloadState *dlstate = user_data;
+	PackageDownloadData *data = user_data;
+	GlobalDownloadData *global_data = data->global_download_data;
 
-	if (dlstate->last_mirror_url)
+	if (global_data->last_mirror_url)
 		goto out;
 
-	dlstate->last_mirror_url = g_strdup (url);
-	dlstate->last_mirror_failure_message = g_strdup (message);
- out:
+	global_data->last_mirror_url = g_strdup (url);
+	global_data->last_mirror_failure_message = g_strdup (message);
+out:
 	return LR_CB_OK;
 }
 
@@ -1686,22 +1740,55 @@ hif_source_download_package (HifSource *source,
 			     HifState *state,
 			     GError **error)
 {
+	_cleanup_ptrarray_unref_ GPtrArray *packages = g_ptr_array_new ();
+	_cleanup_free_ gchar *basename = NULL;
+
+	g_ptr_array_add (packages, pkg);
+
+	if (!hif_source_download_packages (source, packages, directory, state, error))
+		return NULL;
+
+	/* build return value */
+	basename = g_path_get_basename (hy_package_get_location (pkg));
+	return g_build_filename (directory, basename, NULL);
+}
+
+/**
+ * hif_source_download_packages:
+ * @source: a #HifSource instance.
+ * @packages: (element-type HyPackage): an array of packages, must be from this source
+ * @directory: the destination directory.
+ * @state: a #HifState.
+ * @error: a #GError or %NULL.
+ *
+ * Downloads multiple packages from a source.  The target filename
+ * will be equivalent to `g_path_get_basename (hy_package_get_location
+ * (pkg))`.
+ *
+ * Since: 0.2.3
+ **/
+gboolean
+hif_source_download_packages (HifSource *source,
+                              GPtrArray *packages,
+                              const gchar *directory,
+                              HifState *state,
+                              GError **error)
+{
 	HifSourcePrivate *priv = GET_PRIVATE (source);
 	char *checksum_str = NULL;
 	const unsigned char *checksum;
-	gboolean ret;
-	gchar *loc = NULL;
+	gboolean ret = FALSE;
+	guint i;
 	int checksum_type;
 	LrPackageTarget *target = NULL;
-	GSList *packages = NULL;
-	struct DownloadState dlstate = { 0, };
+	GSList *package_targets = NULL;
+	GlobalDownloadData global_data = { 0, };
 	_cleanup_error_free_ GError *error_local = NULL;
-	_cleanup_free_ gchar *basename = NULL;
 	_cleanup_free_ gchar *directory_slash = NULL;
 
 	/* ensure we reset the values from the keyfile */
 	if (!hif_source_set_keyfile_data (source, error))
-		return NULL;
+		goto out;
 
 	/* if nothing specified then use cachedir */
 	if (directory == NULL) {
@@ -1725,42 +1812,59 @@ hif_source_download_package (HifSource *source,
 
 	/* is a local repo, i.e. we just need to copy */
 	if (hif_source_is_local (source)) {
-		hif_package_set_source (pkg, source);
-		if (!hif_source_copy_package (pkg, directory, state, error))
-			goto out;
+		/* the number of packages to copy */
+		hif_state_set_number_steps (state, packages->len);
+
+		for (i = 0; i < packages->len; i++) {
+			HyPackage pkg = packages->pdata[i];
+			HifState *state_loop = hif_state_get_child (state);
+
+			hif_package_set_source (pkg, source);
+			if (!hif_source_copy_package (pkg, directory, state_loop, error))
+				goto out;
+			if (!hif_state_done (state, error))
+				goto out;
+		}
 		goto done;
 	}
 
-	g_debug ("downloading %s to %s",
-		 hy_package_get_location (pkg),
-		 directory_slash);
+	global_data.download_size = hif_package_array_get_download_size (packages);
+	for (i = 0; i < packages->len; i++) {
+		HyPackage pkg = packages->pdata[i];
+		PackageDownloadData *data;
 
-	checksum = hy_package_get_chksum (pkg, &checksum_type);
-	checksum_str = hy_chksum_str (checksum, checksum_type);
-	hif_state_action_start (state,
-				HIF_STATE_ACTION_DOWNLOAD_PACKAGES,
-				hif_package_get_id (pkg));
+		g_debug ("downloading %s to %s",
+			 hy_package_get_location (pkg),
+			 directory_slash);
 
-	dlstate.state = state;
+		data = g_slice_new0 (PackageDownloadData);
+		data->pkg = pkg;
+		data->state = state;
+		data->global_download_data = &global_data;
 
-	target = lr_packagetarget_new_v2 (priv->repo_handle,
-					  hy_package_get_location (pkg),
-					  directory_slash,
-					  hif_source_checksum_hy_to_lr (checksum_type),
-					  checksum_str,
-					  0, /* size unknown */
-					  hy_package_get_baseurl (pkg),
-					  TRUE,
-					  package_download_update_state_cb,
-					  &dlstate,
-					  NULL,
-					  mirrorlist_failure_cb,
-					  error);
-	if (target == NULL)
-		goto out;
+		checksum = hy_package_get_chksum (pkg, &checksum_type);
+		checksum_str = hy_chksum_str (checksum, checksum_type);
+
+		target = lr_packagetarget_new_v2 (priv->repo_handle,
+		                                  hy_package_get_location (pkg),
+		                                  directory_slash,
+		                                  hif_source_checksum_hy_to_lr (checksum_type),
+		                                  checksum_str,
+		                                  hy_package_get_downloadsize (pkg),
+		                                  hy_package_get_baseurl (pkg),
+		                                  TRUE,
+		                                  package_download_update_state_cb,
+		                                  data,
+		                                  package_download_end_cb,
+		                                  mirrorlist_failure_cb,
+		                                  error);
+		if (target == NULL)
+			goto out;
 	
-	packages = g_slist_prepend (packages, target);
-	ret = lr_download_packages (packages, LR_PACKAGEDOWNLOAD_FAILFAST, &error_local);
+		package_targets = g_slist_prepend (package_targets, target);
+	}
+
+	ret = lr_download_packages (package_targets, LR_PACKAGEDOWNLOAD_FAILFAST, &error_local);
 	if (!ret) {
 		if (g_error_matches (error_local,
 				     LR_PACKAGE_DOWNLOADER_ERROR,
@@ -1768,9 +1872,9 @@ hif_source_download_package (HifSource *source,
 			/* ignore */
 			g_clear_error (&error_local);
 		} else {
-			if (dlstate.last_mirror_failure_message) {
+			if (global_data.last_mirror_failure_message) {
 				_cleanup_free_ gchar *orig_message = error_local->message;
-				error_local->message = g_strconcat (orig_message, "; Last error: ", dlstate.last_mirror_failure_message, NULL);
+				error_local->message = g_strconcat (orig_message, "; Last error: ", global_data.last_mirror_failure_message, NULL);
 			}
 			g_propagate_error (error, error_local);
 			error_local = NULL;
@@ -1779,19 +1883,15 @@ hif_source_download_package (HifSource *source,
 	} 
 
 done:
-	/* build return value */
-	basename = g_path_get_basename (hy_package_get_location (pkg));
-	loc = g_build_filename (directory_slash, basename, NULL);
+	ret = TRUE;
 out:
 	lr_handle_setopt (priv->repo_handle, NULL, LRO_PROGRESSCB, NULL);
 	lr_handle_setopt (priv->repo_handle, NULL, LRO_PROGRESSDATA, 0xdeadbeef);
-	if (target != NULL)
-		lr_packagetarget_free (target);
-	g_free (dlstate.last_mirror_failure_message);
-	g_free (dlstate.last_mirror_url);
-	g_slist_free (packages);
+	g_free (global_data.last_mirror_failure_message);
+	g_free (global_data.last_mirror_url);
+	g_slist_free_full (package_targets, (GDestroyNotify) lr_packagetarget_free);
 	hy_free (checksum_str);
-	return loc;
+	return ret;
 }
 
 /**

--- a/libhif/hif-source.h
+++ b/libhif/hif-source.h
@@ -193,6 +193,11 @@ gchar		*hif_source_download_package	(HifSource		*source,
 						 const gchar		*directory,
 						 HifState		*state,
 						 GError			**error);
+gboolean	 hif_source_download_packages	(HifSource		*source,
+						 GPtrArray		*pkgs,
+						 const gchar		*directory,
+						 HifState		*state,
+						 GError			**error);
 #endif
 
 G_END_DECLS

--- a/libhif/hif-transaction.c
+++ b/libhif/hif-transaction.c
@@ -1082,22 +1082,6 @@ hif_transaction_write_yumdb (HifTransaction *transaction,
 	return hif_state_done (state, error);
 }
 
-static guint64
-hif_transaction_get_download_size (HifTransaction *transaction)
-{
-	HifTransactionPrivate *priv = GET_PRIVATE (transaction);
-	guint i;
-	guint64 download_size = 0;
-
-	for (i = 0; i < priv->pkgs_to_download->len; i++) {
-		HyPackage pkg = g_ptr_array_index (priv->pkgs_to_download, i);
-
-		download_size += hy_package_get_downloadsize (pkg);
-	}
-
-	return download_size;
-}
-
 static gboolean
 hif_transaction_check_free_space (HifTransaction *transaction,
                                   GError **error)
@@ -1109,7 +1093,7 @@ hif_transaction_check_free_space (HifTransaction *transaction,
 	_cleanup_object_unref_ GFile *file = NULL;
 	_cleanup_object_unref_ GFileInfo *filesystem_info = NULL;
 
-	download_size = hif_transaction_get_download_size (transaction);
+	download_size = hif_package_array_get_download_size (priv->pkgs_to_download);
 
 	cachedir = hif_context_get_cache_dir (priv->context);
 	if (cachedir == NULL) {


### PR DESCRIPTION
This is https://github.com/rpm-software-management/libhif/pull/62 reworked.

Changes include reworking the HifState handling so that parallel download progress info is correctly passed down, fixes at least two crashers in the new code, comments etc added and some code style issues fixed, and finally rebased on the 0_2_X branch.

I'll do a matching patch for master too if this looks good.

Fedora QA has been asking for this for some time now as the PackageKit download speed has been sub par compared to DNF. This makes it an order of magnitude faster in my testing; a F23->F24 upgrade download that previously took 1-2 hours is now done in mere 5 minutes.