### PR TITLE
[merged] .gitignore: New file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+# These are currently the only two things that
+# show up in a srcdir != builddir build.
+docs/libhif/version.xml
+libhif/hif-version.h


### PR DESCRIPTION
In my automake projects I use `git.mk` but we can't do that with
cmake.  Cmake has good support for srcdir != builddir, so let's assume
people are doing that, and just ignore the few artifacts we create in
srcdir.