### PR TITLE
[merged] (apichange) package: Make hif_package_get_nevra() const

### DIFF
--- a/libhif/hy-hth.c
+++ b/libhif/hy-hth.c
@@ -61,7 +61,7 @@ static void execute_print(HifSack *sack, HyQuery q, int show_obsoletes)
     const int count = plist->len;
     for (int i = 0; i < count; ++i) {
         HifPackage *pkg = g_ptr_array_index(plist, i);
-        char *nvra = hif_package_get_nevra(pkg);
+        const char *nvra = hif_package_get_nevra(pkg);
         const char *reponame = hif_package_get_reponame(pkg);
 
         printf("found package: %s [%s]\n", nvra, reponame);
@@ -83,15 +83,13 @@ static void execute_print(HifSack *sack, HyQuery q, int show_obsoletes)
             const int ocount = olist->len;
             for (int j = 0; j < ocount; ++j) {
                 HifPackage *opkg = g_ptr_array_index(olist, j);
-                char *onvra = hif_package_get_nevra(opkg);
+                const char *onvra = hif_package_get_nevra(opkg);
                 printf("obsoleting: %s\n", onvra);
-                g_free(onvra);
             }
             g_ptr_array_unref(olist);
             hy_query_free(qobs);
             g_object_unref(obsoletes);
         }
-        g_free(nvra);
     }
     g_ptr_array_unref(plist);
 }
@@ -215,10 +213,9 @@ erase(HifSack *sack, const char *name)
     printf("erasure count: %d\n", plist->len);
     for (unsigned int i = 0; i < plist->len; ++i) {
         HifPackage *pkg = g_ptr_array_index(plist, i);
-        char *nvra = hif_package_get_nevra(pkg);
+        const char *nvra = hif_package_get_nevra(pkg);
 
         printf("erasing %s\n", nvra);
-        g_free(nvra);
     }
 
     hy_goal_free(goal);
@@ -245,20 +242,18 @@ static void update(HifSack *sack, HifPackage *pkg)
     printf("upgrade count: %d\n", plist->len);
     for (unsigned int i = 0; i < plist->len; ++i) {
         HifPackage *upkg = g_ptr_array_index(plist, i);
-        char *nvra = hif_package_get_nevra(upkg);
+        const char *nvra = hif_package_get_nevra(upkg);
         char *location = hif_package_get_location(upkg);
         GPtrArray *obsoleted = hy_goal_list_obsoleted_by_package(goal, upkg);
         HifPackage *installed = g_ptr_array_index(obsoleted, 0);
-        char *nvra_installed = hif_package_get_nevra(installed);
+        const char *nvra_installed = hif_package_get_nevra(installed);
 
         printf("upgrading: %s using %s\n", nvra, location);
         printf("\tfrom: %s\n", nvra_installed);
         printf("\tsize: %lu kB\n", hif_package_get_size(upkg) / 1024);
 
-        g_free(nvra_installed);
         g_ptr_array_unref(obsoleted);
         g_free(location);
-        g_free(nvra);
     }
     g_ptr_array_unref(plist);
     // handle installs
@@ -266,14 +261,13 @@ static void update(HifSack *sack, HifPackage *pkg)
     printf("install count: %d\n", plist->len);
     for (unsigned int i = 0; i < plist->len; ++i) {
         HifPackage *ipkg = g_ptr_array_index(plist, i);
-        char *nvra = hif_package_get_nevra(ipkg);
+        const char *nvra = hif_package_get_nevra(ipkg);
         char *location = hif_package_get_location(ipkg);
 
         printf("installing: %s using %s\n", nvra, location);
         printf("\tsize: %lu kB\n", hif_package_get_size(ipkg) / 1024);
 
         g_free(location);
-        g_free(nvra);
     }
     g_ptr_array_unref(plist);
 

--- a/libhif/hy-package.c
+++ b/libhif/hy-package.c
@@ -366,15 +366,15 @@ hif_package_get_baseurl(HifPackage *pkg)
  *
  * Gets the package NEVRA.
  *
- * Returns: (transfer full): a string, or %NULL
+ * Returns: (transfer none): a string, or %NULL
  *
  * Since: 0.7.0
  */
-char *
+const char *
 hif_package_get_nevra(HifPackage *pkg)
 {
     Solvable *s = get_solvable(pkg);
-    return g_strdup(pool_solvable2str(hif_package_get_pool(pkg), s));
+    return pool_solvable2str(hif_package_get_pool(pkg), s);
 }
 
 /**

--- a/libhif/hy-package.h
+++ b/libhif/hy-package.h
@@ -53,7 +53,7 @@ int          hif_package_evr_cmp        (HifPackage *pkg1, HifPackage *pkg2);
 
 char        *hif_package_get_location   (HifPackage *pkg);
 const char  *hif_package_get_baseurl    (HifPackage *pkg);
-char        *hif_package_get_nevra      (HifPackage *pkg);
+const char  *hif_package_get_nevra      (HifPackage *pkg);
 char        *hif_package_get_sourcerpm  (HifPackage *pkg);
 char        *hif_package_get_version    (HifPackage *pkg);
 char        *hif_package_get_release    (HifPackage *pkg);

--- a/python/hawkey/package-py.c
+++ b/python/hawkey/package-py.c
@@ -151,22 +151,20 @@ static PyObject *
 package_repr(_PackageObject *self)
 {
     HifPackage *pkg = self->package;
-    char *nevra = hif_package_get_nevra(pkg);
+    const char *nevra = hif_package_get_nevra(pkg);
     PyObject *repr;
 
     repr = PyString_FromFormat("<hawkey.Package object id %ld, %s, %s>",
                                package_hash(self), nevra,
                                hif_package_get_reponame(pkg));
-    g_free(nevra);
     return repr;
 }
 
 static PyObject *
 package_str(_PackageObject *self)
 {
-    char *cstr = hif_package_get_nevra(self->package);
+    const char *cstr = hif_package_get_nevra(self->package);
     PyObject *ret = PyString_FromString(cstr);
-    g_free(cstr);
     return ret;
 }
 

--- a/tests/hawkey/test_goal.c
+++ b/tests/hawkey/test_goal.c
@@ -222,9 +222,8 @@ START_TEST(test_goal_install_selector)
     assert_iueo(goal, 1, 0, 0, 0);
 
     GPtrArray *plist = hy_goal_list_installs(goal, NULL);
-    char *nvra = hif_package_get_nevra(g_ptr_array_index(plist, 0));
+    const char *nvra = hif_package_get_nevra(g_ptr_array_index(plist, 0));
     ck_assert_str_eq(nvra, "semolina-2-0.i686");
-    g_free(nvra);
     g_ptr_array_unref(plist);
     hy_goal_free(goal);
 }

--- a/tests/hawkey/test_query.c
+++ b/tests/hawkey/test_query.c
@@ -323,9 +323,8 @@ START_TEST(test_query_pkg)
     pset = hy_query_run_set(q2);
     fail_unless(hif_packageset_count(pset) == 1);
     HifPackage *pkg = hif_packageset_get_clone(pset, 0);
-    char *nvra = hif_package_get_nevra(pkg);
+    const char *nvra = hif_package_get_nevra(pkg);
     ck_assert_str_eq(nvra, "jay-6.0-0.x86_64");
-    g_free(nvra);
     g_object_unref(pkg);
 
     g_object_unref(pset);
@@ -918,12 +917,10 @@ START_TEST(test_query_nevra_glob)
     ck_assert_int_eq(plist->len, 2);
     HifPackage *pkg1 = g_ptr_array_index(plist, 0);
     HifPackage *pkg2 = g_ptr_array_index(plist, 1);
-    char *nevra1 = hif_package_get_nevra(pkg1);
-    char *nevra2 = hif_package_get_nevra(pkg2);
+    const char *nevra1 = hif_package_get_nevra(pkg1);
+    const char *nevra2 = hif_package_get_nevra(pkg2);
     ck_assert_str_eq(nevra1, "penny-4-1.noarch");
     ck_assert_str_eq(nevra2, "penny-lib-4-1.x86_64");
-    g_free(nevra1);
-    g_free(nevra2);
     g_ptr_array_unref(plist);
     hy_query_free(q);
 }
@@ -941,9 +938,8 @@ START_TEST(test_query_nevra)
 
     ck_assert_int_eq(plist->len, 1);
     HifPackage *pkg1 = g_ptr_array_index(plist, 0);
-    char *nevra1 = hif_package_get_nevra(pkg1);
+    const char *nevra1 = hif_package_get_nevra(pkg1);
     ck_assert_str_eq(nevra1, "penny-4-1.noarch");
-    g_free(nevra1);
     g_ptr_array_unref(plist);
     hy_query_free(q);
 }

--- a/tests/hawkey/testsys.c
+++ b/tests/hawkey/testsys.c
@@ -40,9 +40,8 @@
 void
 assert_nevra_eq(HifPackage *pkg, const char *nevra)
 {
-    char *pkg_nevra = hif_package_get_nevra(pkg);
+    const char *pkg_nevra = hif_package_get_nevra(pkg);
     ck_assert_str_eq(pkg_nevra, nevra);
-    g_free(pkg_nevra);
 }
 
 HifPackage *
@@ -78,9 +77,8 @@ dump_packagelist(GPtrArray *plist, int free)
     for (guint i = 0; i < plist->len; ++i) {
         HifPackage *pkg = g_ptr_array_index(plist, i);
         Solvable *s = pool_id2solvable(hif_package_get_pool(pkg), hif_package_get_id(pkg));
-        char *nvra = hif_package_get_nevra(pkg);
+        const char *nvra = hif_package_get_nevra(pkg);
         printf("\t%s @%s\n", nvra, s->repo->name);
-        g_free(nvra);
     }
     if (free)
         g_ptr_array_unref(plist);


### PR DESCRIPTION
I use this function a lot, and it's a lot nicer if it's const.  I
don't know why we'd explicitly `strdup()` when libsolv is already
caching things for us.