### PR TITLE
[merged] iutil: Demote "no running kernel" to debug, not warning

### DIFF
--- a/libhif/hy-iutil.c
+++ b/libhif/hy-iutil.c
@@ -356,7 +356,7 @@ running_kernel(HifSack *sack)
     uname(&un);
     char *fn = pool_tmpjoin(pool, "/boot/vmlinuz-", un.release, NULL);
     if (access(fn, F_OK)) {
-        g_warning("running_kernel(): no matching file: %s.", fn);
+        g_debug("running_kernel(): no matching file: %s.", fn);
         return -1;
     }
 


### PR DESCRIPTION
Previously in #143 we changed this code to stop warning for
rpm-ostree, where we always create an install root.

Now, I'm working on a micro yum-alike for a Docker base image, and
we're again triggering the warning because Docker base images don't
have kernels, we inherit them from the host.

I considered trying to detect whether or not we're in a container, but
down that path leads nontrivial maintenance pain.

This warning is for something that, if it happens outside of a testing
environment, the system is *already* screwed.  Ensuring dnf doesn't
remove the running kernel is something for an integration test to
ensure.

Further, I think it'd be a lot saner for this code to live in a higher
level, since dnf already has "protected packages" code, and it could
just as easily detect the kernel and protect it.