### PR TITLE
spec: Remove hawkey Obsoletes

### DIFF
--- a/libhif.spec
+++ b/libhif.spec
@@ -31,7 +31,6 @@ BuildRequires:  pkgconfig(gobject-introspection-1.0)
 BuildRequires:  rpm-devel >= 4.11.0
 
 Requires:       libsolv%{?_isa} >= %{libsolv_version}
-Obsoletes:      hawkey < 0.7.0
 
 %description
 A Library providing simplified C and Python API to libsolv.


### PR DESCRIPTION
This never made any sense, as libhif is not an equivalent provider of the hawkey API. It is not only fundamentally incompatible, it can be installed in parallel to the hawkey C library.

It also makes things messier than it needs to be.

I considered also modifying the build system to be able to optionally not build the legacy hawkey Python API, but I don't think that's necessary. If it is desired, I can make a separate PR for that, or alternatively I can add it to hawkey so that the C libraries can coexist and things can smoothly move to libhif based hawkey Python API.

The Obsoletes breaks the coexistence of DNF 2.0 and VMware's tdnf on the same system, since tdnf uses the hawkey C API.