### PR TITLE
[merged] sack: Make internal helper function static

### DIFF
--- a/libdnf/dnf-sack.c
+++ b/libdnf/dnf-sack.c
@@ -1047,7 +1047,7 @@ dnf_sack_get_installonly_limit(DnfSack *sack)
     return priv->installonly_limit;
 }
 
-Repo *
+static Repo *
 dnf_sack_setup_cmdline_repo(DnfSack *sack)
 {
     DnfSackPrivate *priv = GET_PRIVATE(sack);


### PR DESCRIPTION
To avoid a complier warning about a public function without a prototype.
AFAICS from commit df6f7004d626fa8ce6eebc1516a445c1162df538
where this was introduced, it wasn't intended to be exported.