### PR TITLE
[merged] sack: Fix a possible null pointer dereference in finalize

### DIFF
--- a/libdnf/dnf-sack.c
+++ b/libdnf/dnf-sack.c
@@ -107,6 +107,8 @@ dnf_sack_finalize(GObject *object)
 
     FOR_REPOS(i, repo) {
         HyRepo hrepo = repo->appdata;
+        if (!hrepo)
+            continue;
         hy_repo_free(hrepo);
     }
     g_free(priv->cache_dir);


### PR DESCRIPTION
I just caught this in a debugger, no idea how to reproduce:

```
Thread 96 "PK-Backend" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fffe3a8a700 (LWP 7427)]
0x00007fffec6c3b09 in hy_repo_free (repo=0x0) at /home/kalev/fedora-git/PackageKit/PackageKit-1.1.4-20160810/libhif-c0a107bc7ccc82dced93382bc55ff254944fdb21/libdnf/hy-repo.c:220
220	    if (--repo->nrefs > 0)
Missing separate debuginfos, use: dnf debuginfo-install PackageKit-1.1.4-0.0.20160810.fc25.kalev10.x86_64
(gdb) bt
#0  0x00007fffec6c3b09 in hy_repo_free (repo=0x0) at /home/kalev/fedora-git/PackageKit/PackageKit-1.1.4-20160810/libhif-c0a107bc7ccc82dced93382bc55ff254944fdb21/libdnf/hy-repo.c:220
#1  0x00007fffec6c41cc in dnf_sack_finalize (object=0x5555557b9ed0 [DnfSack]) at /home/kalev/fedora-git/PackageKit/PackageKit-1.1.4-20160810/libhif-c0a107bc7ccc82dced93382bc55ff254944fdb21/libdnf/dnf-sack.c:110
#2  0x00007ffff6eb611a in g_object_unref (_object=0x5555557b9ed0) at gobject.c:3183
#3  0x00007fffec8f9392 in dnf_sack_cache_item_free (cache_item=0x55555587c000) at pk-backend-dnf.c:139
#4  0x00007ffff6bcc088 in g_hash_table_remove_internal (hash_table=0x5555557e7860 = {...}, key=0x555555bb8a80, notify=1) at ghash.c:1358
#5  0x00007fffec8fa4b7 in dnf_utils_create_sack_for_filters (job=0x555555b7c4b0 [PkBackendJob], filters=327680, create_flags=DNF_CREATE_SACK_FLAG_USE_CACHE, state=0x555555baf4c0 [DnfState], error=0x7fffe3a89d10) at pk-backend-dnf.c:666
#6  0x00007fffec8fb04c in pk_backend_search_thread (job=0x555555b7c4b0 [PkBackendJob], params=0x555555b3b210, user_data=0x0) at pk-backend-dnf.c:936
#7  0x0000555555577e29 in pk_backend_job_thread_setup (thread_data=0x555555f4d9e0) at pk-backend-job.c:813
#8  0x00007ffff6c03d38 in g_thread_proxy (data=0x5555560f3ed0) at gthread.c:780
#9  0x00007ffff697f5ca in start_thread (arg=0x7fffe3a8a700) at pthread_create.c:333
#10 0x00007ffff66b8f6d in clone () at ../sysdeps/unix/sysv/linux/x86_64/clone.S:109
(gdb) frame 1
#1  0x00007fffec6c41cc in dnf_sack_finalize (object=0x5555557b9ed0 [DnfSack]) at /home/kalev/fedora-git/PackageKit/PackageKit-1.1.4-20160810/libhif-c0a107bc7ccc82dced93382bc55ff254944fdb21/libdnf/dnf-sack.c:110
110	        hy_repo_free(hrepo);
(gdb) p repo
$1 = (Repo *) 0x555555ba3680
(gdb) p *repo
$2 = {name = 0x555555bbc100 "@System", repoid = 1, appdata = 0x0, pool = 0x555555da2d10, start = 2, end = 3308, nsolvables = 3306, disabled = 0, priority = 0, subpriority = 0, idarraydata = 0x7fffe3126010, 
  idarraysize = 113045, nrepodata = 2, rpmdbid = 0x555555e696e0}
(gdb) p i
$3 = 1
```