### PR TITLE
[merged] report all problem rules to user (RhBug:1148627)

### DIFF
--- a/libdnf/hy-goal.c
+++ b/libdnf/hy-goal.c
@@ -46,6 +46,7 @@
 #include "hy-selector-private.h"
 #include "hy-util.h"
 
+#define BLOCK_SIZE 15
 
 struct _SolutionCallback {
     HyGoal goal;
@@ -940,6 +941,50 @@ hy_goal_describe_problem(HyGoal goal, unsigned i)
     const char *problem = solver_problemruleinfo2str(goal->solv,
                                                      type, source, target, dep);
     return g_strdup(problem);
+}
+
+/**
+ * List describing failed rules in solving problem 'i'.
+ *
+ * Caller is responsible for freeing the returned string list.
+ */
+char **
+hy_goal_describe_problem_rules(HyGoal goal, unsigned i)
+{
+    const char **problist = NULL;
+    int p = 0;
+    /* internal error */
+    if (i >= (unsigned) hy_goal_count_problems(goal))
+        return NULL;
+    // problem is not in libsolv - removal of protected packages
+    if (i >= (unsigned) solver_problem_count(goal->solv)) {
+        problist = solv_extend(problist, p, 1, sizeof(char*), BLOCK_SIZE);
+        problist[p++] = hy_goal_describe_problem(goal, i);
+        problist = solv_extend(problist, p, 1, sizeof(char*), BLOCK_SIZE);
+        problist[p++] = NULL;
+        return problist;
+    }
+
+    Queue pq;
+    Id rid, source, target, dep;
+    SolverRuleinfo type;
+    const char *problem;
+    int j;
+    queue_init(&pq);
+    // this libsolv interface indexes from 1 (we do from 0), so:
+    solver_findallproblemrules(goal->solv, i+1, &pq);
+    for (j = 0; j < pq.count; j++) {
+        rid = pq.elements[j];
+        type = solver_ruleinfo(goal->solv, rid, &source, &target, &dep);
+        problem = solver_problemruleinfo2str(goal->solv,
+                                             type, source, target, dep);
+        problist = solv_extend(problist, p, 1, sizeof(char*), BLOCK_SIZE);
+        problist[p++] = g_strdup(problem);
+    }
+    problist = solv_extend(problist, p, 1, sizeof(char*), BLOCK_SIZE);
+    problist[p++] = NULL;
+    queue_free(&pq);
+    return problist;
 }
 
 /**

--- a/libdnf/hy-goal.h
+++ b/libdnf/hy-goal.h
@@ -99,6 +99,7 @@ int hy_goal_run_all_flags(HyGoal goal, hy_solution_callback cb, void *cb_data,
 /* problems */
 int hy_goal_count_problems(HyGoal goal);
 char *hy_goal_describe_problem(HyGoal goal, unsigned i);
+char **hy_goal_describe_problem_rules(HyGoal goal, unsigned i);
 int hy_goal_log_decisions(HyGoal goal);
 gboolean hy_goal_write_debugdata(HyGoal goal, const char *dir, GError **error);
 

--- a/python/hawkey/__init__.py
+++ b/python/hawkey/__init__.py
@@ -218,6 +218,10 @@ class Goal(_hawkey.Goal):
     def problems(self):
         return [self.describe_problem(i) for i in range(0, self.count_problems())]
 
+    @property
+    def problem_rules(self):
+        return [self.describe_problem_rules(i) for i in range(0, self.count_problems())]
+
     def run(self, callback=None, **kwargs):
         ret = super(Goal, self).run(**kwargs)
         if callback:

--- a/python/hawkey/goal-py.c
+++ b/python/hawkey/goal-py.c
@@ -639,6 +639,7 @@ static struct PyMethodDef goal_methods[] = {
      METH_VARARGS | METH_KEYWORDS, NULL},
     {"count_problems",        (PyCFunction)count_problems,        METH_NOARGS,        NULL},
     {"describe_problem",(PyCFunction)describe_problem,        METH_O,                NULL},
+    {"describe_problem_rules",(PyCFunction)describe_problem_rules,        METH_O,                NULL},
     {"log_decisions",   (PyCFunction)log_decisions,        METH_NOARGS,        NULL},
     {"write_debugdata", (PyCFunction)write_debugdata,        METH_O,                NULL},
     {"list_erasures",        (PyCFunction)list_erasures,        METH_NOARGS,        NULL},

--- a/python/hawkey/goal-py.c
+++ b/python/hawkey/goal-py.c
@@ -463,6 +463,27 @@ describe_problem(_GoalObject *self, PyObject *index_obj)
 }
 
 static PyObject *
+describe_problem_rules(_GoalObject *self, PyObject *index_obj)
+{
+    PyObject *list;
+
+    if (!PyInt_Check(index_obj)) {
+        PyErr_SetString(PyExc_TypeError, "An integer value expected.");
+        return NULL;
+    }
+    const char **plist = hy_goal_describe_problem_rules(self->goal,
+                                                       PyLong_AsLong(index_obj));
+    if (plist == NULL) {
+        PyErr_SetString(PyExc_ValueError, "Index out of range.");
+        return NULL;
+    }
+
+    list = strlist_to_pylist(plist);
+    g_free(plist);
+    return list;
+}
+
+static PyObject *
 log_decisions(_GoalObject *self, PyObject *unused)
 {
     if (hy_goal_log_decisions(self->goal))


### PR DESCRIPTION
get more info from libsolv about failed transactions; e.g.
```
./bin/dnf-2 install libreoffice gimp -x xml-commons-apis,xdg-utils
Last metadata expiration check: 0:56:40 ago on Tue Sep 20 14:31:28 2016 CEST.
Error: 
 Problem 0: conflicting requests
  - nothing provides xdg-utils needed by gimp-2:2.8.16-1.fc24.1.x86_64
  - nothing provides xdg-utils needed by gimp-2:2.8.18-1.fc24.x86_64
 Problem 1: conflicting requests
  - package libreoffice-1:5.1.3.2-6.fc24.x86_64 requires libreoffice-base(x86-64) = 1:5.1.3.2-6.fc24, but none of the providers can be installed
  - package libreoffice-1:5.1.5.2-6.fc24.x86_64 requires libreoffice-base(x86-64) = 1:5.1.5.2-6.fc24, but none of the providers can be installed
  - package libreoffice-base-1:5.1.3.2-6.fc24.x86_64 requires pentaho-reporting-flow-engine, but none of the providers can be installed
  - package libreoffice-base-1:5.1.5.2-6.fc24.x86_64 requires pentaho-reporting-flow-engine, but none of the providers can be installed
  - package pentaho-reporting-flow-engine-1:0.9.4-12.fc24.noarch requires liblayout >= 0.2.10, but none of the providers can be installed
  - nothing provides xml-commons-apis needed by liblayout-0.2.10-12.fc24.noarch
(try to add '--allowerasing' to command line to replace conflicting packages)
```