### PR TITLE
all: Squash some minor compiler warnings

### DIFF
--- a/libdnf/hy-goal.c
+++ b/libdnf/hy-goal.c
@@ -956,7 +956,7 @@ hy_goal_describe_problem(HyGoal goal, unsigned i)
 char **
 hy_goal_describe_problem_rules(HyGoal goal, unsigned i)
 {
-    const char **problist = NULL;
+    char **problist = NULL;
     int p = 0;
     /* internal error */
     if (i >= (unsigned) hy_goal_count_problems(goal))

--- a/python/hawkey/goal-py.c
+++ b/python/hawkey/goal-py.c
@@ -472,14 +472,14 @@ describe_problem_rules(_GoalObject *self, PyObject *index_obj)
         PyErr_SetString(PyExc_TypeError, "An integer value expected.");
         return NULL;
     }
-    const char **plist = hy_goal_describe_problem_rules(self->goal,
-                                                       PyLong_AsLong(index_obj));
+    char **plist = hy_goal_describe_problem_rules(self->goal,
+						  PyLong_AsLong(index_obj));
     if (plist == NULL) {
         PyErr_SetString(PyExc_ValueError, "Index out of range.");
         return NULL;
     }
 
-    list = strlist_to_pylist(plist);
+    list = strlist_to_pylist((const char **)plist);
     g_free(plist);
     return list;
 }

--- a/tests/hawkey/test_goal.c
+++ b/tests/hawkey/test_goal.c
@@ -1359,7 +1359,7 @@ START_TEST(test_goal_get_solution)
         slist = hy_goal_get_solution(goal, p);
         for (guint i = 0; i < slist->len; ++i) {
             DnfSolution *sol = g_ptr_array_index(slist, i);
-            fail_unless(dnf_solution_get_action(sol) == expected_actions[p][i]);
+            fail_unless((gint)dnf_solution_get_action(sol) == expected_actions[p][i]);
             fail_unless(g_strcmp0(dnf_solution_get_old(sol), expected_old[p][i]) == 0);
             fail_unless(g_strcmp0(dnf_solution_get_new(sol), expected_new[p][i]) == 0);
         }


### PR DESCRIPTION
All harmless type mismatches, but it's good to squash harmless
warnings so the real ones stand out.