### PR TITLE
[merged] context: Change install() to honor exact NEVRAs, provides, paths

### DIFF
--- a/libdnf/hy-nevra.c
+++ b/libdnf/hy-nevra.c
@@ -171,3 +171,12 @@ char *hy_nevra_get_evr(HyNevra nevra)
         return g_strdup_printf ("%s-%s", nevra->version, nevra->release);
     return g_strdup_printf ("%d:%s-%s", nevra->epoch, nevra->version, nevra->release);
 }
+
+gboolean
+hy_nevra_has_just_name(HyNevra nevra)
+{
+  return nevra->name != NULL &&
+    nevra->epoch == -1 &&
+    nevra->version == NULL &&
+    nevra->release == NULL;
+}

--- a/libdnf/hy-nevra.h
+++ b/libdnf/hy-nevra.h
@@ -46,6 +46,7 @@ void hy_nevra_set_string(HyNevra nevra, int which, const char* str_val);
 HyQuery hy_nevra_to_query(HyNevra nevra, DnfSack *sack);
 int hy_nevra_evr_cmp(HyNevra nevra1, HyNevra nevra2, DnfSack *sack);
 char *hy_nevra_get_evr(HyNevra nevra);
+gboolean hy_nevra_has_just_name(HyNevra nevra);
 
 G_END_DECLS
 

--- a/libdnf/hy-selector.c
+++ b/libdnf/hy-selector.c
@@ -1,4 +1,4 @@
-/*
+/* -*- Mode: C; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4 -*-
  * Copyright (C) 2012-2014 Red Hat, Inc.
  *
  * Licensed under the GNU Lesser General Public License Version 2.1
@@ -152,4 +152,17 @@ hy_selector_matches(HySelector sltr)
     queue_free(&solvables);
     queue_free(&job);
     return plist;
+}
+
+gboolean
+hy_selector_has_matches(HySelector sltr)
+{
+    /* Doing things this way obviously wastes allocations,
+     * but it avoids code duplication.  All of the callers
+     * seem to really want this, so at some point if that's
+     * true, let's nuke hy_selector_matches().
+     */
+    g_autoptr(GPtrArray) selector_matches = NULL;
+    selector_matches = hy_selector_matches(sltr);
+    return selector_matches->len > 0;
 }

--- a/libdnf/hy-selector.h
+++ b/libdnf/hy-selector.h
@@ -32,6 +32,7 @@ HySelector hy_selector_create(DnfSack *sack);
 void hy_selector_free(HySelector sltr);
 int hy_selector_set(HySelector sltr, int keyname, int cmp_type,
                     const char *match);
+gboolean hy_selector_has_matches(HySelector sltr);
 GPtrArray *hy_selector_matches(HySelector sltr);
 
 G_END_DECLS

--- a/libdnf/hy-subject.h
+++ b/libdnf/hy-subject.h
@@ -68,6 +68,9 @@ HyPossibilities hy_subject_nevra_possibilities_real(HySubject subject,
     HyForm *forms, DnfSack *sack, int flags);
 int hy_possibilities_next_nevra(HyPossibilities iter, HyNevra *out_nevra);
 
+HyQuery hy_subject_get_best_query(HySubject subject, DnfSack *sack, gboolean with_provides);
+HySelector hy_subject_get_best_selector(HySubject subject, DnfSack *sack);
+
 G_END_DECLS
 
 #endif


### PR DESCRIPTION
The ability to pin to specific package versions comes up in
several contexts.  Ansible's `pkg` module supports specifying
name-version pairs, like `bash-4.30`.

And for rpm-ostree, several users have requested the ability to
hardcode specific versions in the input.  In this model, one might
have just a single large rpm-md repo with many package versions, and
control the input via the treefile.

I moved down most of a dnf function into C for this - at some point
ideally we can change dnf to use this.  The new libdnf APIs mirror
those of the Python code in dnf.

Hence, this additionally teaches `dnf_context_install()` about
provides and (absolute) file paths.

For now, I didn't try to lower any of the code that uses globs, as
doing so is another whole level of complexity.

https://github.com/projectatomic/rpm-ostree/issues/390
