### PR TITLE
[merged] fixing SIGSEGV in dnf_package_get_location()

### DIFF
--- a/libdnf/hy-package.c
+++ b/libdnf/hy-package.c
@@ -339,7 +339,9 @@ const char *
 dnf_package_get_location(DnfPackage *pkg)
 {
     Solvable *s = get_solvable(pkg);
-    repo_internalize_trigger(s->repo);
+    if (s->repo) {
+        repo_internalize_trigger(s->repo);
+    }
     return solvable_get_location(s, NULL);
 }
 


### PR DESCRIPTION
Program received signal SIGSEGV, Segmentation fault.
0x00007fffe6af7b10 in repo_internalize_trigger () from /lib64/libdnf.so.1

in case of malformed local rpm file