### PR TITLE
Enable pkg keyname for selectors

### DIFF
--- a/libdnf/hy-selector-private.h
+++ b/libdnf/hy-selector-private.h
@@ -31,6 +31,7 @@ struct _HySelector {
     struct _Filter *f_name;
     struct _Filter *f_provides;
     struct _Filter *f_reponame;
+    struct _Filter *f_pkg;
 };
 
 static inline DnfSack *selector_sack(HySelector sltr) { return sltr->sack; }

--- a/libdnf/hy-selector.c
+++ b/libdnf/hy-selector.c
@@ -123,6 +123,10 @@ int
 hy_selector_pkg_set(HySelector sltr, int keyname, int cmp_type, const DnfPackageSet *pset)
 {
     DnfSack *sack = selector_sack(sltr);
+
+    if (sltr->f_name || sltr->f_provides || sltr->f_file) {
+        return DNF_ERROR_BAD_SELECTOR;
+    }
     return replace_pkg_filter(sack, &sltr->f_pkg, keyname, cmp_type, pset);
 }
 
@@ -140,17 +144,17 @@ hy_selector_set(HySelector sltr, int keyname, int cmp_type, const char *match)
     case HY_PKG_VERSION:
         return replace_filter(sack, &sltr->f_evr, keyname, cmp_type, match);
     case HY_PKG_NAME:
-        if (sltr->f_provides || sltr->f_file)
+        if (sltr->f_provides || sltr->f_file || sltr->f_pkg)
             return DNF_ERROR_BAD_SELECTOR;
         return replace_filter(sack, &sltr->f_name, keyname, cmp_type, match);
     case HY_PKG_PROVIDES:
-        if (sltr->f_name || sltr->f_file)
+        if (sltr->f_name || sltr->f_file || sltr->f_pkg)
             return DNF_ERROR_BAD_SELECTOR;
         return replace_filter(sack, &sltr->f_provides, keyname, cmp_type, match);
     case HY_PKG_REPONAME:
         return replace_filter(sack, &sltr->f_reponame, keyname, cmp_type, match);
     case HY_PKG_FILE:
-        if (sltr->f_name || sltr->f_provides)
+        if (sltr->f_name || sltr->f_provides || sltr->f_pkg)
             return DNF_ERROR_BAD_SELECTOR;
         return replace_filter(sack, &sltr->f_file, keyname, cmp_type, match);
     default:

--- a/libdnf/hy-selector.h
+++ b/libdnf/hy-selector.h
@@ -30,6 +30,8 @@ G_BEGIN_DECLS
 
 HySelector hy_selector_create(DnfSack *sack);
 void hy_selector_free(HySelector sltr);
+int hy_selector_pkg_set(HySelector sltr, int keyname, int cmp_type,
+                        const DnfPackageSet *pset);
 int hy_selector_set(HySelector sltr, int keyname, int cmp_type,
                     const char *match);
 gboolean hy_selector_has_matches(HySelector sltr);

--- a/python/hawkey/selector-py.c
+++ b/python/hawkey/selector-py.c
@@ -111,11 +111,15 @@ set(_SelectorObject *self, PyObject *args)
         if (queryObject_Check(match)) {
             HyQuery *target = queryFromPyObject(match);
             pset = hy_query_run_set(target);
-        } else {
+        } else if (PyList_Check(match)) {
             DnfSack *sack = sackFromPyObject(self->sack);
             assert(sack);
             pset = pyseq_to_packageset(match, sack);
+        }  else {
+            (ret2e(DNF_ERROR_BAD_SELECTOR, "Invalid value type: Only List and Query supported"));
+            return NULL;
         }
+
         if (ret2e(hy_selector_pkg_set(self->sltr, keyname, cmp_type, pset),
                   "Invalid Selector spec." )) {
                return NULL;


### PR DESCRIPTION
The  pkg keyname can be used with query or list of packages.