### PR TITLE
Set SOLVER_SETEVR for selector pkg flag

### DIFF
--- a/libdnf/hy-goal.c
+++ b/libdnf/hy-goal.c
@@ -504,7 +504,7 @@ filter_pkg2job(DnfSack *sack, const struct _Filter *f, Queue *job)
         queue_push(&pkgs, id);
     }
     what = pool_queuetowhatprovides(pool, &pkgs);
-    queue_push2(job, SOLVER_SOLVABLE_ONE_OF|SOLVER_SETARCH, what);
+    queue_push2(job, SOLVER_SOLVABLE_ONE_OF|SOLVER_SETARCH|SOLVER_SETEVR, what);
     return 0;
 }
 


### PR DESCRIPTION
It should solve the problem with installing package with lower version that
installed.

If selector is used with pkg flag for install of installed package with lower
version than installed, it rise conflict instead for downgrading pkg.

This flag is used if name and evr flaks are used for selectors.

The patch is essential for campaign where all selectors flag will be replaced by
pkg flag.