### PR TITLE
goal: return reason user if transaction was assembled without resolving

### DIFF
--- a/libdnf/hy-goal.c
+++ b/libdnf/hy-goal.c
@@ -1179,8 +1179,8 @@ int
 hy_goal_get_reason(HyGoal goal, DnfPackage *pkg)
 {
     //solver_get_recommendations
-
-    assert(goal->solv);
+    if (!goal->solv)
+        return HY_REASON_USER;
     Id info;
     int reason = solver_describe_decision(goal->solv, dnf_package_get_id(pkg), &info);
 

--- a/libdnf/hy-goal.c
+++ b/libdnf/hy-goal.c
@@ -1179,7 +1179,7 @@ int
 hy_goal_get_reason(HyGoal goal, DnfPackage *pkg)
 {
     //solver_get_recommendations
-    if (!goal->solv)
+    if (goal->solv == NULL)
         return HY_REASON_USER;
     Id info;
     int reason = solver_describe_decision(goal->solv, dnf_package_get_id(pkg), &info);


### PR DESCRIPTION
This is required by dnf history cmd as it doesn't resolve undo/redo transactions
and get_reason is consequently called in the transaction output.