### PR TITLE
context: Support usr/etc/os-release too

### DIFF
--- a/libdnf/dnf-context.c
+++ b/libdnf/dnf-context.c
@@ -1038,6 +1038,15 @@ dnf_context_set_os_release(DnfContext *context, GError **error)
         return FALSE;
 
     if (contents == NULL) {
+        g_free(os_release);
+        /* For rpm-ostree use on systems that haven't adapted to usr/lib/os-release yet,
+         * e.g. CentOS 7 Core AH */
+        os_release = g_build_filename(source_root, "usr/etc/os-release", NULL);
+        if (!dnf_get_file_contents_allow_noent(os_release, &contents, NULL, error))
+            return FALSE;
+    }
+
+    if (contents == NULL) {
         g_free (os_release);
         os_release = g_build_filename(source_root, "usr/lib/os-release", NULL);
         if (!dnf_get_file_contents_allow_noent(os_release, &contents, NULL, error))

--- a/libdnf/dnf-context.c
+++ b/libdnf/dnf-context.c
@@ -1055,7 +1055,7 @@ dnf_context_set_os_release(DnfContext *context, GError **error)
 
     if (contents == NULL) {
         g_set_error(error, DNF_ERROR, DNF_ERROR_FILE_NOT_FOUND,
-                    "Could not find os-release in etc/ nor in usr/lib "
+                    "Could not find os-release in etc/, usr/etc, or usr/lib "
                     "under source root '%s'", source_root);
         return FALSE;
     }


### PR DESCRIPTION
For CentOS 7 Core AH and rpm-ostree, which now checks out the new
target root for rebasing to get the correct `os-release` data.