### PR TITLE
nevra_to_selector: default to package name

### DIFF
--- a/libdnf/hy-subject.c
+++ b/libdnf/hy-subject.c
@@ -299,7 +299,7 @@ nevra_to_selector(HyNevra nevra, DnfSack *sack)
     HySelector selector = hy_selector_create(sack);
 
     if (hy_nevra_has_just_name(nevra)) {
-        hy_selector_set(selector, HY_PKG_PROVIDES, HY_EQ,
+        hy_selector_set(selector, HY_PKG_NAME, HY_EQ,
                         hy_nevra_get_string(nevra, HY_NEVRA_NAME));
     } else {
         const char *str = hy_nevra_get_string(nevra, HY_NEVRA_NAME);


### PR DESCRIPTION
In #204, we changed `dnf_context_install()` so that it accepts any
allowed subject forms, defaulting to a provides if just a package name
is given. However, interpreting it as a provides can cause libsolv to
make suboptimal choices: https://github.com/openSUSE/libsolv/issues/165

It seems safer in that case to just revert to HY_PKG_NAME instead, which
was the same behaviour as before #204.

Closes: #220