### PR TITLE
build: Propagate CFLAGS to g-ir-scanner

### DIFF
--- a/libdnf/CMakeLists.txt
+++ b/libdnf/CMakeLists.txt
@@ -133,7 +133,7 @@ if (GOBJECT_INTROSPECTION_FOUND)
         set(GIR_TYPELIB "${GIR_PREFIX}.typelib")
 
         add_custom_command(OUTPUT ${GIR_XML}
-            COMMAND ${GOBJECT_INTROSPECTION_1.0_G_IR_SCANNER}
+            COMMAND env CFLAGS=${CMAKE_C_FLAGS} ${GOBJECT_INTROSPECTION_1.0_G_IR_SCANNER}
                     --namespace=Dnf
                     --nsversion=${DNF_SO_VERSION}.0
                     --library-path=${CMAKE_CURRENT_BINARY_DIR}


### PR DESCRIPTION
I'm trying to build rpm-ostree with `-fsanitize=address`, and
the libdnf introspection build bombs out because it doesn't include
`-fsanitize` in the scanner build.

`Makefile.introspection` does this for us, but since we're using
CMake we need to propagate manually.