### PR TITLE
tree-wide: Squash -Werror=incompatible-pointer-type warnings

### DIFF
--- a/libdnf/hy-goal.c
+++ b/libdnf/hy-goal.c
@@ -493,7 +493,7 @@ filter_pkg2job(DnfSack *sack, const struct _Filter *f, Queue *job)
         return 0;
     assert(f->nmatches == 1);
     Pool *pool = dnf_sack_get_pool(sack);
-    const DnfPackageSet *pset = f->matches[0].pset;
+    DnfPackageSet *pset = f->matches[0].pset;
     const int count = dnf_packageset_count(pset);
     Id what;
     Id id = -1;

--- a/libdnf/hy-selector.c
+++ b/libdnf/hy-selector.c
@@ -75,7 +75,7 @@ replace_pkg_filter(DnfSack *sack, struct _Filter **fp, int keyname, int cmp_type
     f->keyname = keyname;
     f->cmp_type = cmp_type;
     f->match_type = _HY_PKG;
-    f->matches[0].pset = dnf_packageset_clone(pset);
+    f->matches[0].pset = dnf_packageset_clone((DnfPackageSet*)pset);
     return 0;
 }
 

--- a/python/hawkey/selector-py.c
+++ b/python/hawkey/selector-py.c
@@ -109,7 +109,7 @@ set(_SelectorObject *self, PyObject *args)
     if (keyname == HY_PKG) {
         const DnfPackageSet *pset;
         if (queryObject_Check(match)) {
-            HyQuery *target = queryFromPyObject(match);
+            HyQuery target = queryFromPyObject(match);
             pset = hy_query_run_set(target);
         } else if (PyList_Check(match)) {
             DnfSack *sack = sackFromPyObject(self->sack);

--- a/tests/hawkey/test_goal.c
+++ b/tests/hawkey/test_goal.c
@@ -244,9 +244,8 @@ START_TEST(test_goal_install_selector_obsoletes_first)
     assert_iueo(goal, 1, 0, 0, 0);
 
     GPtrArray *plist = hy_goal_list_installs(goal, NULL);
-    char *nvra = dnf_package_get_nevra(g_ptr_array_index(plist, 0));
+    const char *nvra = dnf_package_get_nevra(g_ptr_array_index(plist, 0));
     ck_assert_str_eq(nvra, "B-1-0.noarch");
-    g_free(nvra);
     g_ptr_array_unref(plist);
     hy_goal_free(goal);
 }


### PR DESCRIPTION
This should really be fatal by default, but sadly the `gcc-4.8.5`
in CentOS 7 is too old to speak it, and we don't do the "detect
available options" here in cmake.

Relatedly, someone seems to be using `const <SomeStructType>` in
various places, but we basically don't do that in the glib world
unfortunately, and trying to do so will mean endless pain in casting.
I didn't unwind all of it, just added some casts for now.