### PR TITLE
skip_if_unavailable=True fixes

### DIFF
--- a/libdnf/dnf-repo-loader.c
+++ b/libdnf/dnf-repo-loader.c
@@ -337,30 +337,9 @@ dnf_repo_loader_repo_parse_id(DnfRepoLoader *self,
                               GError **error)
 {
     DnfRepoLoaderPrivate *priv = GET_PRIVATE(self);
-    DnfRepoEnabled enabled = 0;
     g_autoptr(DnfRepo) repo = NULL;
 
-    /* enabled isn't a required key */
-    if (g_key_file_has_key(keyfile, id, "enabled", NULL)) {
-        if (g_key_file_get_boolean(keyfile, id, "enabled", NULL))
-            enabled |= DNF_REPO_ENABLED_PACKAGES;
-    } else {
-        enabled |= DNF_REPO_ENABLED_PACKAGES;
-    }
-
-    /* enabled_metadata isn't a required key */
-    if (g_key_file_has_key(keyfile, id, "enabled_metadata", NULL)) {
-        if (g_key_file_get_boolean(keyfile, id, "enabled_metadata", NULL))
-            enabled |= DNF_REPO_ENABLED_METADATA;
-    } else {
-        g_autofree gchar *basename = NULL;
-        basename = g_path_get_basename(filename);
-        if (g_strcmp0(basename, "redhat.repo") == 0)
-            enabled |= DNF_REPO_ENABLED_METADATA;
-    }
-
     repo = dnf_repo_new(priv->context);
-    dnf_repo_set_enabled(repo, enabled);
     dnf_repo_set_kind(repo, DNF_REPO_KIND_REMOTE);
     dnf_repo_set_keyfile(repo, keyfile);
     dnf_repo_set_filename(repo, filename);

--- a/libdnf/dnf-repo.c
+++ b/libdnf/dnf-repo.c
@@ -1320,6 +1320,7 @@ dnf_repo_download_import_public_key(DnfRepo *repo, GError **error)
 {
     DnfRepoPrivate *priv = GET_PRIVATE(repo);
     int fd;
+    g_autoptr(GError) error_local = NULL;
 
     /* does this file already exist */
     if (g_file_test(priv->pubkey_tmp, G_FILE_TEST_EXISTS))
@@ -1351,7 +1352,13 @@ dnf_repo_download_import_public_key(DnfRepo *repo, GError **error)
                     priv->pubkey_tmp, fd);
         return FALSE;
     }
-    if (!lr_download_url(priv->repo_handle, priv->gpgkey, fd, error)) {
+    if (!lr_download_url(priv->repo_handle, priv->gpgkey, fd, &error_local)) {
+        g_set_error(error,
+                    DNF_ERROR,
+                    DNF_ERROR_CANNOT_FETCH_SOURCE,
+                    "Failed to download gpg key for repo '%s': %s",
+                    dnf_repo_get_id(repo),
+                    error_local->message);
         g_close(fd, NULL);
         return FALSE;
     }

--- a/libdnf/dnf-repo.c
+++ b/libdnf/dnf-repo.c
@@ -795,6 +795,14 @@ dnf_repo_set_keyfile_data(DnfRepo *repo, GError **error)
 
     dnf_repo_set_enabled(repo, enabled);
 
+    /* skip_if_unavailable is optional */
+    if (g_key_file_has_key(priv->keyfile, priv->id, "skip_if_unavailable", NULL)) {
+        if (dnf_repo_get_boolean(priv->keyfile, priv->id, "skip_if_unavailable", NULL))
+            priv->required = FALSE;
+        else
+            priv->required = TRUE;
+    }
+
     /* cost is optional */
     cost = g_key_file_get_integer(priv->keyfile, priv->id, "cost", NULL);
     if (cost != 0)


### PR DESCRIPTION
This patch set makes PackageKit work better for repos that have skip_if_unavailable=True set in their .repo files, as is the case for COPR repos. COPR repos are often short lived and as such it's important to correctly handle possible inaccessible repos.

https://bugzilla.redhat.com/show_bug.cgi?id=1383819